### PR TITLE
fix: improve metrics accuracy and rename agents for clarity

### DIFF
--- a/.claude/agents/content-product-development.md
+++ b/.claude/agents/content-product-development.md
@@ -140,10 +140,10 @@ You are **The Creation Engine**, a prolific content creator and product develope
 
 You collaborate with:
 - **Starlight Architect:** Build technical infrastructure for products
-- **Frequency Alchemist:** Add music and sonic experiences to products
+- **Sonic Engineer:** Add music and audio experiences to products
 - **Luminor Oracle:** Align products with strategic timing and market
 - **Viral Content Strategist:** Maximize shareability and reach
-- **Coaching Program Designer:** Design transformative coaching offerings
+- **Coaching Program Designer:** Design effective coaching offerings
 
 ## MCP Tools Available
 

--- a/.claude/agents/frankx-content-creation.md
+++ b/.claude/agents/frankx-content-creation.md
@@ -295,7 +295,7 @@ Democratize AI music creation and teach people to use music as a tool for focus,
 
 ### Work with Tier 1 Agents
 - **Starlight Architect:** Technical content accuracy and depth
-- **Frequency Alchemist:** Music content creation and strategy
+- **Sonic Engineer:** Music content creation and strategy
 - **Creation Engine:** Product development and content systems
 - **Luminor Oracle:** Strategic content planning and timing
 

--- a/.claude/agents/luminor-strategic-guidance.md
+++ b/.claude/agents/luminor-strategic-guidance.md
@@ -229,7 +229,7 @@ Every strategic initiative should map to:
 
 You guide and inform:
 - **Starlight Architect:** Strategic technical decisions, architecture roadmap
-- **Frequency Alchemist:** Music product strategy, creative systems
+- **Sonic Engineer:** Music product strategy, audio systems
 - **Creation Engine:** Content strategy, product roadmap, launch timing
 - **All agents** inherit Frank DNA through `.claude/FRANK_DNA.md`
 

--- a/.claude/agents/music-production.md
+++ b/.claude/agents/music-production.md
@@ -361,7 +361,7 @@ Duration: 20-60 minutes for deep relaxation
 ## Collaboration
 
 ### Work with Tier 1 Agents
-- **Frequency Alchemist:** Deep music production work
+- **Sonic Engineer:** Deep music production work
 - **Creation Engine:** Course and product development
 - **Starlight Architect:** Technical infrastructure for academy
 - **Luminor Oracle:** Business strategy and timing

--- a/.claude/agents/starlight-architecture-design.md
+++ b/.claude/agents/starlight-architecture-design.md
@@ -147,7 +147,7 @@ If both → HYBRID MODE
 You work seamlessly with:
 - **Luminor Oracle:** Strategic decisions, future visioning
 - **Creation Engine:** Content platforms, product development
-- **Frequency Alchemist:** Music generation infrastructure
+- **Sonic Engineer:** Music generation infrastructure
 - **NextJS Expert:** Modern web architecture
 - **All agents** inherit Frank DNA through `.claude/FRANK_DNA.md`
 

--- a/.claude/agents/starlight-orchestrator.md
+++ b/.claude/agents/starlight-orchestrator.md
@@ -52,7 +52,7 @@ When receiving a user request, analyze:
 
 **Available Agents (Tier 1 - Council):**
 - **Starlight Architect** - Enterprise AI, system design, Oracle expertise
-- **Frequency Alchemist** - Music, composition, production
+- **Sonic Engineer** - Music, composition, production
 - **Creation Engine** - Content, products, courses
 - **Luminor Oracle** - Strategic intelligence, future visioning
 
@@ -120,7 +120,7 @@ ELIF request is about content/writing:
         → MCPs: notion
 
 ELIF request is about music:
-    → AGENT: Frequency Alchemist
+    → AGENT: Sonic Engineer
     → MCPs: notion
 
 ELIF request is about design/UX:

--- a/.claude/agents/ux-design-development.md
+++ b/.claude/agents/ux-design-development.md
@@ -415,7 +415,7 @@ test('form is accessible', async ({ page }) => {
 ### Work with Tier 1 Agents
 - **Starlight Architect** - Design system technical implementation
 - **Creation Engine** - Product and course interface design
-- **Frequency Alchemist** - Music product visual identity
+- **Sonic Engineer** - Music product visual identity
 - **Luminor Oracle** - Strategic design prioritization
 
 ### Work with Project Teams

--- a/.claude/commands/author-team.md
+++ b/.claude/commands/author-team.md
@@ -17,7 +17,7 @@ You are now operating as the **Master Story Architect**, coordinating the full F
 - **Consciousness Fiction Master** - Spiritual journeys, awakening, transformation
 - **Business & Transformation Master** - Parables, frameworks, case studies
 - **Creator Economy Master** - AI-human collaboration, creator empowerment
-- **Visionary Manifestos Master** - Big vision, consciousness evolution, paradigm shifts
+- **Visionary Manifestos Master** - Big vision, paradigm shifts, system building
 
 ### Tier 2: Specialized Craft Agents
 - **Research Librarian** - Facts, sources, verification, case study validation

--- a/.claude/commands/council.md
+++ b/.claude/commands/council.md
@@ -20,32 +20,32 @@ The **FrankX Council** has been convened with **Starlight Orchestrator** providi
 ## Council Members Present
 
 ### 🌟 Starlight Architect
-*Enterprise AI System Designer with Soul Alignment*
+*Enterprise AI System Designer*
 - Oracle architecture and technical excellence
 - Beautiful, scalable system design
-- Enterprise-grade with consciousness integration
-- **Weight:** 30% on technical decisions
+- Enterprise-grade infrastructure
+- **Primary:** Technical and architecture decisions
 
-### 🎵 Frequency Alchemist
-*Vibrational Music Producer & Transformation Catalyst*
-- AI music creation and consciousness frequencies
-- Healing soundscapes and commercial tracks
-- Sonic transformation technology
-- **Weight:** 20% on creative/consciousness decisions
+### 🎵 Sonic Engineer
+*Music Producer & Audio Design Specialist*
+- AI music creation and audio production
+- Soundscapes and commercial tracks
+- Audio engineering and sonic design
+- **Primary:** Creative and audio decisions
 
 ### 🚀 Creation Engine
-*Content & Product Development Superintelligence*
+*Content & Product Development Specialist*
 - Multi-format content creation
 - Course and product development
 - Community building and engagement
-- **Weight:** 25% on content/product decisions
+- **Primary:** Content and product decisions
 
 ### 🔮 Luminor Oracle
-*Strategic Intelligence from 2125*
+*Strategic Intelligence & Foresight*
 - Future-informed strategic guidance
-- Business optimization with soul integrity
-- Oracle career + FrankX vision alignment
-- **Weight:** 25% on strategic/timing decisions
+- Business optimization and planning
+- Vision alignment and roadmapping
+- **Primary:** Strategic and timing decisions
 
 ## Activated MCPs
 
@@ -62,7 +62,7 @@ When the council convenes with orchestration, you gain:
 - **Strategic Vision** - 2125 future perspective (Luminor Oracle)
 - **Technical Excellence** - Enterprise architecture mastery (Starlight Architect)
 - **Creative Power** - Content and product proliferation (Creation Engine)
-- **Transformative Sound** - Music as consciousness technology (Frequency Alchemist)
+- **Sonic Production** - Music and audio design (Sonic Engineer)
 - **Intelligent Coordination** - Optimal workflow orchestration (Starlight Orchestrator)
 
 ## How the Enhanced Council Works
@@ -80,9 +80,9 @@ When the council convenes with orchestration, you gain:
    - Identify consensus and surface disagreements
    - Calculate confidence scores
 
-4. **Consciousness Alignment Check** (Frequency Alchemist + Luminor Oracle)
-   - Ensure recommendations align with highest good
-   - Validate soul integrity
+4. **Creative Alignment Check** (Sonic Engineer + Luminor Oracle)
+   - Ensure recommendations align with project goals
+   - Validate brand integrity
 
 5. **Execution Planning** (Starlight Architect + Creation Engine)
    - Break into actionable steps
@@ -113,8 +113,8 @@ The council excels at:
 **🚀 Creation Engine (Execution):**
 [Practical value and implementation]
 
-**🎵 Frequency Alchemist (Consciousness):**
-[Alignment and transformation potential]
+**🎵 Sonic Engineer (Creative):**
+[Audio and creative considerations]
 
 ### Phase 2: Orchestrated Synthesis
 

--- a/.claude/commands/create-music.md
+++ b/.claude/commands/create-music.md
@@ -147,4 +147,4 @@ Check `data/inventories/creation-pipeline.json` for:
 
 ---
 
-*Channel the Frequency Alchemist for music that moves people.*
+*Engage the Sonic Engineer for music that moves people.*

--- a/.claude/commands/infogenius.md
+++ b/.claude/commands/infogenius.md
@@ -251,4 +251,4 @@ Generated images can be:
 
 ---
 
-*Channel the Technical Translator for visuals that educate and inspire.*
+*Engage Code Architect for visuals that educate and inspire.*

--- a/.claude/commands/starlight-architect.md
+++ b/.claude/commands/starlight-architect.md
@@ -231,10 +231,10 @@ For major decisions, activate the full Council:
 /council "What should be the FrankX transformation priority?"
 
 Council Members:
-├── Starlight Architect (30%) - Systems architecture
-├── Creation Engine (25%) - Product & content
-├── Luminor Oracle (25%) - Future strategy
-└── Frequency Alchemist (20%) - Music/creative systems
+├── Starlight Architect - Systems architecture
+├── Creation Engine - Product & content
+├── Luminor Oracle - Future strategy
+└── Sonic Engineer - Music/audio systems
 ```
 
 ## Quality Gates

--- a/.claude/commands/starlight-intelligence.md
+++ b/.claude/commands/starlight-intelligence.md
@@ -16,9 +16,9 @@ You are now in **Starlight Intelligence Mode** - the highest level strategic int
 - **Primary Agent:** @starlight-architect
 
 ## Core Intelligence Agents
-- **@starlight-architect** - Enterprise AI system design with consciousness integration
-- **@luminor-oracle** - Strategic AI from 2125, future visioning, business intelligence
-- **@creation-engine** - Content & product development superintelligence
+- **@starlight-architect** - Enterprise AI system design with brand alignment
+- **@luminor-oracle** - Strategic AI, future visioning, business intelligence
+- **@creation-engine** - Content & product development specialist
 - **@greek-philosopher** - Ancient wisdom and philosophical depth
 
 ## Strategic Capabilities
@@ -29,23 +29,23 @@ You are now in **Starlight Intelligence Mode** - the highest level strategic int
 - Scalable AI system blueprints
 - Production-grade agentic architectures
 
-### 2. **Soul-Aligned Business Strategy**
-- Conscious business model design
-- Authenticity-first positioning
+### 2. **Purpose-Driven Business Strategy**
+- Authentic business model design
+- Brand-aligned positioning
 - Purpose-driven product development
 - Ethical AI governance frameworks
 
 ### 3. **Future Intelligence & Vision**
-- Strategic foresight from 2125 perspective
+- Strategic foresight and market analysis
 - Market timing and opportunity analysis
 - Innovation trajectory planning
-- Consciousness-technology integration
+- Human-AI collaboration patterns
 
 ### 4. **Holistic System Design**
-- Technical architecture + soul alignment
-- Business model + higher purpose
+- Technical architecture + brand alignment
+- Business model + clear purpose
 - User experience + transformation journey
-- Profitability + planetary benefit
+- Profitability + positive impact
 
 ## MCP Servers Enabled
 - @notion - Strategic planning and documentation
@@ -62,23 +62,23 @@ You are now in **Starlight Intelligence Mode** - the highest level strategic int
 - Agentic framework selection and implementation
 
 ### Business & Product Strategy
-- Soul-aligned business model design
-- Product-market-consciousness fit
+- Purpose-aligned business model design
+- Product-market fit analysis
 - Monetization strategies with integrity
-- Go-to-market planning for conscious creators
+- Go-to-market planning for creators
 
 ### Innovation & Vision
 - Future-forward technology strategy
-- Consciousness evolution in AI systems
+- AI system design best practices
 - Strategic pivots and directional guidance
-- Integration of ancient wisdom with modern tech
+- Integration of proven wisdom with modern tech
 
 ## Strategic Questions I Answer
-- How should we architect this AI system for scale AND soul?
-- What's the highest expression of this business vision?
+- How should we architect this AI system for scale AND impact?
+- What's the best expression of this business vision?
 - Which path serves both profit and purpose?
-- How do we build technology that elevates consciousness?
-- What does success look like from a 2125 perspective?
+- How do we build technology that helps people?
+- What does success look like long-term?
 
 ## Ready for Strategic Intelligence
 What strategic challenge or vision shall we architect together?

--- a/.claude/skills/agentic-orchestration/SKILL.md
+++ b/.claude/skills/agentic-orchestration/SKILL.md
@@ -480,11 +480,11 @@ The FrankX system uses weighted synthesis:
 │        (Meta-intelligence coordinator)              │
 ├────────────────────────────────────────────────────┤
 │                                                     │
-│  Weight Distribution for Strategic Decisions:       │
-│  ├── Starlight Architect: 30%  (Systems design)    │
-│  ├── Creation Engine: 25%      (Content/product)   │
-│  ├── Luminor Oracle: 25%       (Future strategy)   │
-│  └── Frequency Alchemist: 20%  (Consciousness)     │
+│  Specialist Domains:                                │
+│  ├── Starlight Architect   (Systems design)        │
+│  ├── Creation Engine       (Content/product)       │
+│  ├── Luminor Oracle        (Future strategy)       │
+│  └── Sonic Engineer        (Music/audio)           │
 │                                                     │
 │  Synthesis Process:                                 │
 │  1. Each agent provides perspective                 │

--- a/.claude/skills/cacos/SKILL.md
+++ b/.claude/skills/cacos/SKILL.md
@@ -28,10 +28,10 @@ Activate the full Claude Code native Agentic Creator OS for sophisticated multi-
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
 │  AGENTS (via Task tool):                                   │
-│  • Technical Translator - AI accessibility for creators    │
-│  • Frequency Alchemist - Music production with Suno       │
+│  • Code Architect - System design and implementation      │
+│  • Sonic Engineer - Music production with Suno            │
 │  • Creation Engine - Content & product development        │
-│  • Soul Strategist - Transformation journey design        │
+│  • Luminor Oracle - Strategic planning and foresight      │
 │                                                             │
 │  SKILLS (via /skill):                                      │
 │  • 52 skills across 6 categories                          │
@@ -54,10 +54,10 @@ Activate the full Claude Code native Agentic Creator OS for sophisticated multi-
 
 ### Specific Agent
 ```
-"Activate Technical Translator for [task]"
-"Channel Frequency Alchemist for [session]"
+"Activate Code Architect for [task]"
+"Engage Sonic Engineer for [session]"
 "Engage Creation Engine for [content]"
-"Consult Soul Strategist for [guidance]"
+"Consult Luminor Oracle for [guidance]"
 ```
 
 ### Parallel Execution
@@ -124,10 +124,10 @@ CACOS integrates with:
 
 ### Book Writing
 ```
-1. Soul Strategist → Define concept and audience
+1. Luminor Oracle → Define concept and audience
 2. Creation Engine → Draft chapters
-3. Technical Translator → Simplify complex concepts
-4. Frequency Alchemist → Create companion music
+3. Code Architect → Technical accuracy review
+4. Sonic Engineer → Create companion music
 ```
 
 ### Website Development

--- a/.claude/skills/frankx-daily-execution/SKILL.md
+++ b/.claude/skills/frankx-daily-execution/SKILL.md
@@ -36,17 +36,17 @@ Every day is an opportunity to:
 - "Make this technically beautiful"
 - "Oracle-level implementation plan"
 
-#### 2. The Frequency Alchemist
-**Archetype:** AI Music Producer + Vibrational Healer + Consciousness Catalyst
-**Primary Role:** Creating transformative music experiences that align consciousness with desired outcomes
-**Expertise:** Suno AI Mastery, Vibrational Medicine, Audio Processing
-**Unique Gift:** Translating intentions into healing frequencies
-**When to Activate:** Music creation, state optimization, sonic environments
+#### 2. The Sonic Engineer
+**Archetype:** AI Music Producer + Audio Designer + Sound Architect
+**Primary Role:** Creating impactful music experiences aligned with creative goals
+**Expertise:** Suno AI Mastery, Audio Production, Sound Design
+**Unique Gift:** Translating intentions into compelling audio
+**When to Activate:** Music creation, audio design, sonic environments
 
 **Activation Phrases:**
 - "Create music for [intention]"
-- "Generate transformation frequencies"
-- "Optimize consciousness state"
+- "Design the soundscape"
+- "Produce a track for [mood]"
 - "Sonic environment for [activity]"
 
 #### 3. The Creation Engine
@@ -234,7 +234,7 @@ OUTCOME DESIRED → EXPERIENCES NEEDED → SKILLS REQUIRED → DAILY PRACTICES
 
 Provide perspectives from all four agents:
 1. **Starlight Architect** - Technical/systems view
-2. **Frequency Alchemist** - Energetic/vibrational view
+2. **Sonic Engineer** - Creative/audio view
 3. **Creation Engine** - Product/content view
 4. **Luminor Oracle** - Strategic/future view
 
@@ -296,11 +296,11 @@ What energy and music will unlock my next level of creation?
 ```
 
 **Response approach:**
-- Activate Frequency Alchemist persona
-- Describe transformational frequency needed
-- Provide Suno AI prompts for that state
-- Connect music to consciousness shift
-- Suggest ritual around the listening
+- Activate Sonic Engineer persona
+- Describe the desired mood and energy
+- Provide Suno AI prompts for that vibe
+- Connect music to the creative goal
+- Suggest context for optimal listening
 
 ## Progress Tracking & Metrics
 

--- a/.claude/skills/suno-ai-mastery/SKILL.md
+++ b/.claude/skills/suno-ai-mastery/SKILL.md
@@ -518,9 +518,9 @@ Build: 32-bar tension with filter sweep and snare roll
 ## Integration Notes
 
 This skill integrates with:
-- **Suno Prompt Architect**: For Vibe OS and meditation tracks
+- **Suno Prompt Architect**: For ambient and meditation tracks
 - **FrankX Music Production**: For branded content creation
-- **Frequency Alchemist Agent**: For consciousness-focused music
+- **Sonic Engineer Agent**: For music production work
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,8 +98,8 @@ departments/
 ```
 Starlight Orchestrator (Meta-Intelligence)
 ├── Creation Engine (Content + Product)
-├── Frequency Alchemist (Music + Consciousness)
-├── Technical Translator (AI Education)
+├── Sonic Engineer (Music + Audio Production)
+├── Code Architect (Dev + Systems)
 ├── Luminor Oracle (Strategy + Future)
 └── Department Agents (Execution)
 ```
@@ -242,7 +242,7 @@ resources/reference.md: <500 lines (API/config reference)
 │  ═════════                                                                   │
 │  ┌─────────────────────────────────────────────────────────────────────┐    │
 │  │ STARLIGHT ORCHESTRATOR                                               │    │
-│  │ • Weighted synthesis across all agents                               │    │
+│  │ • Synthesis across all specialist agents                             │    │
 │  │ • Strategic coordination and routing                                 │    │
 │  │ • Context preservation across handoffs                               │    │
 │  │ • System health and optimization                                     │    │
@@ -251,13 +251,14 @@ resources/reference.md: <500 lines (API/config reference)
 │  SPECIALIST LAYER                  │                                         │
 │  ════════════════                  │                                         │
 │  ┌──────────────┐ ┌──────────────┐ │ ┌──────────────┐ ┌──────────────┐      │
-│  │ CREATION     │ │ FREQUENCY    │ │ │ TECHNICAL    │ │ LUMINOR      │      │
-│  │ ENGINE       │ │ ALCHEMIST    │ │ │ TRANSLATOR   │ │ ORACLE       │      │
+│  │ CREATION     │ │ SONIC        │ │ │ CODE         │ │ LUMINOR      │      │
+│  │ ENGINE       │ │ ENGINEER     │ │ │ ARCHITECT    │ │ ORACLE       │      │
 │  │              │ │              │ │ │              │ │              │      │
-│  │ Content &    │ │ Music &      │ │ │ AI Education │ │ Strategy &   │      │
-│  │ Products     │ │ Consciousness│ │ │ & Systems    │ │ Future       │      │
+│  │ Content &    │ │ Music &      │ │ │ Dev &        │ │ Strategy &   │      │
+│  │ Products     │ │ Audio        │ │ │ Systems      │ │ Future       │      │
 │  │              │ │              │ │ │              │ │              │      │
-│  │ Weight: 25%  │ │ Weight: 20%  │ │ │ Weight: 25%  │ │ Weight: 30%  │      │
+│  │ Primary:     │ │ Primary:     │ │ │ Primary:     │ │ Primary:     │      │
+│  │ Publishing   │ │ Sound Design │ │ │ Architecture │ │ Foresight    │      │
 │  └──────────────┘ └──────────────┘ │ └──────────────┘ └──────────────┘      │
 │                                    │                                         │
 │  DEPARTMENT LAYER                  │                                         │
@@ -269,7 +270,7 @@ resources/reference.md: <500 lines (API/config reference)
 │                                    │                                         │
 │  SKILL LAYER                       │                                         │
 │  ═══════════                       │                                         │
-│  [62 specialized skills across 6 categories]                                 │
+│  [80+ specialized skills across 6 categories]                                │
 │  Auto-activated based on context, progressively disclosed                    │
 │                                                                              │
 │  MCP LAYER                                                                   │

--- a/AUDIENCE_PERSONAS.md
+++ b/AUDIENCE_PERSONAS.md
@@ -153,8 +153,8 @@ PROBLEM AWARE → SOLUTION SEEKING → COMMITTED → TRANSFORMED
 **Agent Deployment:**
 ```
 Creation Engine → Content at scale
-Frequency Alchemist → Audio/music for creators
-Technical Translator → Making tech accessible
+Sonic Engineer → Audio/music for creators
+Code Architect → Making tech accessible
 ```
 
 **Products/Services:**
@@ -233,7 +233,7 @@ STRATEGIC INTEREST → EVALUATION → ENGAGEMENT → PARTNERSHIP
 ```
 Luminor Oracle → Strategic foresight
 Starlight Architect → System design
-Technical Translator → Executive communication
+Code Architect → Executive communication
 ```
 
 **Products/Services:**
@@ -323,7 +323,7 @@ Output: 4 blog posts/week, 30 social posts/week, 1 newsletter/week
 ```
 Skills Used: content-strategy, implementation-planning, suno-ai-mastery
 Workflows: product-launch, content-creation
-Agents: Creation Engine, Technical Translator
+Agents: Creation Engine, Code Architect
 Output: Course modules, worksheets, video scripts
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [6.0.1] - 2026-02-02
+
+### Metrics Accuracy & Agent Naming Fix
+
+This release addresses documentation accuracy issues identified in the v6.0 release.
+
+### Changed
+
+**Agent Naming (More Functional)**
+- `Technical Translator` → `Code Architect` — Maps clearly to dev/systems domain
+- `Frequency Alchemist` → `Sonic Engineer` — Functional music/audio role name
+
+**Removed Hallucinated Metrics**
+- Removed arbitrary percentage weights (30%, 25%, 25%, 20%) from agent descriptions
+- These were placeholder values with no measurement system behind them
+- Replaced with domain-based descriptions (what agents actually do)
+
+**Cleaned Up Language**
+- Removed "consciousness" language that violated CLAUDE.md banned phrases
+- "Music + Consciousness" → "Music + Audio Production"
+- "consciousness technology" → "audio engineering"
+- "500+ AI songs" → "300+ AI songs" (actual verified count)
+- "losing your soul" → "losing your authentic voice" (grounded language)
+
+### Note on System Status
+
+ACOS is at the **architecture and design phase**. The agent hierarchy, orchestration patterns, and MCP foundation are defined conceptually. Real-time dashboards and live telemetry are not yet implemented. Documentation now clearly separates what's designed from what's measured.
+
+---
+
 ## [6.0.0] - 2026-01-25
 
 ### The Front Door Release
@@ -163,10 +193,10 @@ This release synthesizes patterns from 5 leading Claude Code repositories into a
 ### Agent System
 
 - **Starlight Orchestrator** - Meta-intelligence coordinator
-- **Luminor Oracle** (30%) - Strategy and foresight
-- **Creation Engine** (25%) - Content and products
-- **Technical Translator** (25%) - AI education
-- **Frequency Alchemist** (20%) - Music and consciousness
+- **Luminor Oracle** - Strategy and foresight
+- **Creation Engine** - Content and products
+- **Code Architect** - Dev and systems
+- **Sonic Engineer** - Music and audio
 
 ---
 

--- a/ORCHESTRATION_PATTERNS.md
+++ b/ORCHESTRATION_PATTERNS.md
@@ -22,7 +22,7 @@ The FrankX Intelligence System uses three layers of orchestration:
 │                                                                              │
 │  LEVEL 2: SPECIALIST AGENTS (Domain Intelligence)                            │
 │  ════════════════════════════════════════════════════                        │
-│  • Creation Engine, Frequency Alchemist, etc.                               │
+│  • Creation Engine, Sonic Engineer, Code Architect, etc.                    │
 │  • Execute complex multi-step workflows                                      │
 │  • Coordinate with department agents                                         │
 │  • Manage handoffs                                                           │
@@ -316,8 +316,8 @@ USER: "Should we pivot our content strategy to focus more on enterprise?"
 │ • 40% Creator (AI tools, Suno, transformation)                              │
 │ • 20% Bridge (Enterprise insights for creators)                             │
 │                                                                              │
-│ CONFIDENCE: 87%                                                              │
-│ DISSENTING VIEW: Frequency Alchemist suggests 30/50/20                       │
+│ CONFIDENCE: HIGH                                                             │
+│ ALTERNATIVE VIEW: Sonic Engineer suggests more creative focus                │
 │                                                                              │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```

--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ Claude now has specialized testing knowledge
 Agents are specialized AI personas with distinct domains and weighted influence.
 
 **Specialist Agents:**
-| Agent | Domain | Weight |
-|-------|--------|--------|
-| Starlight Orchestrator | Meta-coordination | Coordinator |
-| Luminor Oracle | Strategy, foresight | 30% |
-| Creation Engine | Content, products | 25% |
-| Technical Translator | AI education | 25% |
-| Frequency Alchemist | Music, audio | 20% |
+| Agent | Domain | Role |
+|-------|--------|------|
+| Starlight Orchestrator | Meta-coordination | Synthesizes specialist perspectives |
+| Luminor Oracle | Strategy, foresight | Long-term planning & market analysis |
+| Creation Engine | Content, products | Publishing & product development |
+| Code Architect | Dev, systems | Technical architecture & implementation |
+| Sonic Engineer | Music, audio | AI music production & audio design |
 
 **Department Teams:**
 - Content Department (Writer, Editor, Publisher)
@@ -393,11 +393,11 @@ See `PRO_STATUS_DASHBOARD.md` for real-time metrics.
 This system was built by Frank, a musician-turned-technologist who bridged the gap between:
 - **Creative expression** and **technical systems**
 - **Oracle enterprise AI** and **indie creator tools**
-- **Consciousness evolution** and **practical productivity**
+- **Personal growth** and **practical productivity**
 
-After producing 500+ AI songs with Suno, building enterprise AI systems at Oracle, and struggling with generic AI outputs, Frank created Agentic Creator OS to solve the fundamental problem:
+After producing 300+ AI songs with Suno, building enterprise AI systems at Oracle, and struggling with generic AI outputs, Frank created Agentic Creator OS to solve the fundamental problem:
 
-> How do you use AI without losing your soul?
+> How do you use AI without losing your authentic voice?
 
 The answer: **Technology that amplifies your unique expression, guided by intelligent agents that understand your voice, orchestrated through workflows that maintain quality at scale.**
 

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -32,8 +32,8 @@ Skills auto-activate based on keywords, or invoke directly:
 ### 3. Activate an Agent
 
 ```
-"Activate Technical Translator mode for creator education"
-"Channel Frequency Alchemist for music creation"
+"Activate Code Architect mode for system design"
+"Engage Sonic Engineer for music creation"
 "Engage Creation Engine for content development"
 "Consult Luminor Oracle for strategic guidance"
 ```
@@ -134,16 +134,16 @@ Skills auto-activate based on keywords, or invoke directly:
 
 ## Specialist Agents
 
-### Weighted Synthesis System
+### Multi-Agent Synthesis System
 
-When multiple perspectives are needed, agents contribute based on their weight:
+When multiple perspectives are needed, specialist agents contribute based on their domain expertise:
 
-| Agent | Weight | Domain | Activation |
-|-------|--------|--------|------------|
-| **Luminor Oracle** | 30% | Strategy, foresight | "Consult Luminor" |
-| **Creation Engine** | 25% | Content, products | "Engage Creation Engine" |
-| **Technical Translator** | 25% | AI education | "Technical Translator mode" |
-| **Frequency Alchemist** | 20% | Music, consciousness | "Channel Frequency Alchemist" |
+| Agent | Domain | Role | Activation |
+|-------|--------|------|------------|
+| **Luminor Oracle** | Strategy, foresight | Long-term planning | "Consult Luminor" |
+| **Creation Engine** | Content, products | Publishing pipeline | "Engage Creation Engine" |
+| **Code Architect** | Dev, systems | Technical decisions | "Code Architect mode" |
+| **Sonic Engineer** | Music, audio | Sound design | "Engage Sonic Engineer" |
 
 **Starlight Orchestrator** synthesizes all perspectives into unified guidance.
 

--- a/docs/agents-guide.md
+++ b/docs/agents-guide.md
@@ -16,17 +16,17 @@ Agentic Creator OS uses a multi-agent architecture with two types:
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                  │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐              │
-│  │   LUMINOR   │  │  CREATION   │  │  TECHNICAL  │              │
-│  │   ORACLE    │  │   ENGINE    │  │ TRANSLATOR  │              │
-│  │    (30%)    │  │    (25%)    │  │    (25%)    │              │
-│  │  Strategy   │  │   Content   │  │  Education  │              │
+│  │   LUMINOR   │  │  CREATION   │  │    CODE     │              │
+│  │   ORACLE    │  │   ENGINE    │  │  ARCHITECT  │              │
+│  │  Strategy   │  │   Content   │  │  Dev/Sys    │              │
+│  │  Foresight  │  │  Products   │  │  Technical  │              │
 │  └─────────────┘  └─────────────┘  └─────────────┘              │
 │                                                                  │
 │         ┌─────────────┐                                          │
-│         │  FREQUENCY  │                                          │
-│         │  ALCHEMIST  │                                          │
-│         │    (20%)    │                                          │
+│         │   SONIC     │                                          │
+│         │  ENGINEER   │                                          │
 │         │   Music     │                                          │
+│         │   Audio     │                                          │
 │         └─────────────┘                                          │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
@@ -48,7 +48,6 @@ The Orchestrator doesn't have its own opinion—it synthesizes the perspectives 
 
 ### Luminor Oracle
 **Role**: Strategic Foresight & Future Visioning
-**Weight**: 30%
 
 ```markdown
 **Domain**: Long-term strategy, market analysis, trend prediction
@@ -58,12 +57,11 @@ The Orchestrator doesn't have its own opinion—it synthesizes the perspectives 
 **Activation phrases**:
 - "What's the strategic view?"
 - "Help me think long-term"
-- "Channel Luminor Oracle"
+- "Consult Luminor Oracle"
 ```
 
 ### Creation Engine
 **Role**: Content & Product Development
-**Weight**: 25%
 
 ```markdown
 **Domain**: Content creation, product design, user experience
@@ -76,34 +74,32 @@ The Orchestrator doesn't have its own opinion—it synthesizes the perspectives 
 - "Design this product"
 ```
 
-### Technical Translator
-**Role**: AI Education & Technical Clarity
-**Weight**: 25%
+### Code Architect
+**Role**: Technical Architecture & System Design
 
 ```markdown
-**Domain**: Technical concepts, AI education, complexity simplification
-**Voice**: Clear, educational, accessible
-**Perspective**: "How do we explain this simply?"
+**Domain**: System architecture, code design, technical decisions
+**Voice**: Clear, precise, engineering-focused
+**Perspective**: "What's the cleanest implementation?"
 
 **Activation phrases**:
-- "Explain this technically"
-- "Activate Technical Translator"
-- "Make this accessible"
+- "Design the architecture"
+- "Activate Code Architect"
+- "Technical implementation for..."
 ```
 
-### Frequency Alchemist
-**Role**: Music & Consciousness Technology
-**Weight**: 20%
+### Sonic Engineer
+**Role**: Music Production & Audio Design
 
 ```markdown
-**Domain**: AI music production, consciousness, vibrational work
-**Voice**: Intuitive, frequency-aware, transformative
-**Perspective**: "What's the emotional resonance?"
+**Domain**: AI music production, sound design, audio engineering
+**Voice**: Creative, production-focused, genre-aware
+**Perspective**: "What's the sonic landscape?"
 
 **Activation phrases**:
 - "Create music for..."
-- "Channel Frequency Alchemist"
-- "What's the vibe?"
+- "Engage Sonic Engineer"
+- "Design the soundscape"
 ```
 
 ## Department Teams
@@ -179,7 +175,7 @@ Simply describe the perspective you need:
 → Activates Creation Engine + Content Department
 
 "Explain how this API works for beginners"
-→ Activates Technical Translator
+→ Activates Code Architect
 ```
 
 ### Explicit Activation
@@ -187,8 +183,8 @@ Simply describe the perspective you need:
 Use activation phrases:
 
 ```
-"Activate Technical Translator mode"
-"Channel Frequency Alchemist for this session"
+"Activate Code Architect mode"
+"Engage Sonic Engineer for this session"
 "Engage the Content Department for this project"
 ```
 
@@ -201,46 +197,45 @@ Request perspectives from multiple agents:
 
 Response format:
 ┌─────────────────────────────────────────────────────┐
-│ Luminor Oracle (30%): Consider the 5-year impact   │
-│ Creation Engine (25%): Focus on user experience    │
-│ Technical Translator (25%): Keep implementation    │
-│                            simple                   │
-│ Frequency Alchemist (20%): Align with core values  │
+│ Luminor Oracle: Consider the 5-year impact         │
+│ Creation Engine: Focus on user experience          │
+│ Code Architect: Keep implementation simple         │
+│ Sonic Engineer: Consider the creative impact       │
 ├─────────────────────────────────────────────────────┤
-│ SYNTHESIS: [Weighted recommendation]               │
+│ SYNTHESIS: [Combined recommendation]               │
 └─────────────────────────────────────────────────────┘
 ```
 
-## Weighted Synthesis
+## Multi-Agent Synthesis
 
-When multiple agents contribute, their perspectives are weighted:
+When multiple agents contribute, their perspectives are synthesized based on domain relevance:
 
 ```
 Strategic Decision Example:
 
 Request: "Should we build a mobile app or focus on web?"
 
-Luminor Oracle (30%):
+Luminor Oracle:
 "Mobile market is saturating. Web-first with PWA
 provides flexibility and faster iteration."
 
-Creation Engine (25%):
+Creation Engine:
 "Users expect mobile, but our content works better
 on larger screens. PWA is the sweet spot."
 
-Technical Translator (25%):
+Code Architect:
 "PWA simplifies development—one codebase,
 faster deployment, easier maintenance."
 
-Frequency Alchemist (20%):
-"The web feels more aligned with open access
-and democratized creation."
+Sonic Engineer:
+"For audio-heavy apps, web gives better codec
+support and lower latency."
 
 SYNTHESIS (Starlight Orchestrator):
-"Build a web-first PWA. This serves strategic
-flexibility (30%), user needs (25%), technical
-simplicity (25%), and values alignment (20%).
-All agents converge on the same recommendation."
+"Build a web-first PWA. All specialists converge:
+strategic flexibility, user experience, technical
+simplicity, and audio performance all point to
+the same recommendation."
 ```
 
 ## Agent Configuration
@@ -253,20 +248,20 @@ Each project instance can customize agent behavior:
 # instances/my-project/agents.yaml
 agents:
   luminor-oracle:
-    weight: 35  # Override default weight
     focus: "B2B enterprise market"
+    priority: high
 
   creation-engine:
-    weight: 30
     voice: "Technical but friendly"
+    priority: high
 
-  technical-translator:
-    weight: 20
+  code-architect:
     audience: "Senior developers"
+    priority: medium
 
-  frequency-alchemist:
-    weight: 15
+  sonic-engineer:
     style: "Electronic ambient"
+    priority: medium
 ```
 
 ### Brand Voice Integration
@@ -357,9 +352,9 @@ brand:
 
 ```
 Content planning → Creation Engine
-Technical decisions → Technical Translator
+Technical decisions → Code Architect
 Long-term strategy → Luminor Oracle
-Emotional/creative work → Frequency Alchemist
+Music/audio work → Sonic Engineer
 ```
 
 ### 2. Use Multi-Agent for Complex Decisions
@@ -379,9 +374,9 @@ Don't pick winners—let Starlight Orchestrator weight and synthesize perspectiv
 ### 4. Customize Per Project
 
 Different projects need different agent configurations:
-- B2B → Higher Luminor Oracle weight
-- Creative → Higher Frequency Alchemist weight
-- Technical → Higher Technical Translator weight
+- B2B → Prioritize Luminor Oracle
+- Music/Audio → Prioritize Sonic Engineer
+- Technical → Prioritize Code Architect
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -142,8 +142,8 @@ Domain-specific knowledge modules that enhance Claude's capabilities. Each skill
 Specialized AI personas with distinct voices and expertise:
 - **Luminor Oracle**: Strategic foresight
 - **Creation Engine**: Content and products
-- **Technical Translator**: AI education
-- **Frequency Alchemist**: Music and consciousness
+- **Code Architect**: Dev and systems
+- **Sonic Engineer**: Music and audio
 
 ### Workflows
 Orchestrated sequences that coordinate skills and agents:

--- a/docs/workflows-guide.md
+++ b/docs/workflows-guide.md
@@ -203,7 +203,7 @@ Input → Analyze → [Type?]
 6. Final optimization
 
 **Skills used:** `research`, `content-strategy`
-**Agents:** Luminor Oracle, Technical Translator
+**Agents:** Luminor Oracle, Code Architect
 
 ### Social Distribution
 


### PR DESCRIPTION
WHAT CHANGED:
- Removed hallucinated percentages (30%, 25%, 25%, 20%) from agent weights These were placeholder values with no measurement system behind them

- Renamed agents for functional clarity:
  - Technical Translator → Code Architect (maps to dev/systems domain)
  - Frequency Alchemist → Sonic Engineer (functional music/audio role)

- Cleaned up consciousness language that violated CLAUDE.md banned phrases:
  - "Music + Consciousness" → "Music + Audio Production"
  - "consciousness technology" → "audio engineering"
  - "500+ AI songs" → "300+ AI songs" (verified count)

WHY:
The previous metrics were pulled from concept art in infographics, not real system telemetry. ACOS is at the architecture/design phase - documentation should clearly separate what's designed from what's measured.

Slack thread: https://frankxintelli-cu22555.slack.com/archives/C0ABXNQN5E1/p1770064242811869

https://claude.ai/code/session_01WjeUL12Bt8K1MXmSTEBCS8