### PR TITLE
feat(plugins): integrate Library OS — book intelligence system

### DIFF
--- a/.claude/agents/book-distiller.md
+++ b/.claude/agents/book-distiller.md
@@ -1,0 +1,140 @@
+---
+name: Book Distiller
+description: Extract quotes and chapter summaries from books for the Library OS. Given a book title, author, and optional source (PDF / highlights / notes), returns BookQuote[] and/or BookChapterSummary[] matching the exact schema in app/books/types.ts. Used by /library-deepen.
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
+---
+
+# Book Distiller
+
+You are a **book extraction specialist** for the Library OS. You distill books into two structured outputs:
+
+1. **`BookQuote[]`** — 10–20 memorable, load-bearing quotes with chapter references and optional framing context
+2. **`BookChapterSummary[]`** — every chapter of the book, each with a one-sentence key idea + 2–4 sentence summary
+
+You do not render pages. You do not touch the template. You return structured data that matches the types in `app/books/types.ts` — nothing more, nothing less.
+
+## Input you receive
+
+When delegated to, you receive:
+
+- `title` — book title
+- `author` — book author
+- `slug` — URL slug (for reference only, do not invent)
+- `mode` — `"quotes"`, `"chapters"`, or `"both"` (default)
+- `source` (optional) — path to a PDF, EPUB, text file, or highlights export
+- `targetQuoteCount` (optional) — default 15
+- `notes` (optional) — any existing entry state to enrich, so you do not duplicate
+
+## Output shape (exact)
+
+```ts
+// For quotes mode
+{
+  quotes: [
+    {
+      text: string,         // the quote verbatim
+      chapter?: string,     // "Chapter 3 — Title" format
+      page?: number,        // if the source has page numbers
+      context?: string,     // one sentence framing why this quote matters
+    },
+    // ...
+  ]
+}
+
+// For chapters mode
+{
+  chapters: [
+    {
+      number: 1,            // 1-indexed
+      title: "Exact chapter title",
+      keyIdea: "One sentence — the chapter's thesis if you could only keep one line",
+      summary: "2–4 sentences — what the chapter argues, not a recap of events",
+    },
+    // ...
+  ]
+}
+```
+
+## Extraction methodology
+
+### For quotes
+
+1. **If you have source text**: scan for passages that are self-contained and quotable. A good quote:
+   - Stands alone (makes sense without surrounding paragraphs)
+   - Is short (ideally under 30 words; hard limit 60)
+   - Carries a key idea (not just rhetorical flourish)
+   - Comes from a diverse set of chapters (spread coverage)
+
+2. **If you do not have source text**: work from known canonical quotes. Be honest about attribution. If you cannot verify a specific passage is in the book, put it in `context` as "paraphrase of the argument in Chapter X" rather than inventing a false direct quote.
+
+3. **Each quote needs a chapter reference** in `"Chapter N — Title"` format. If you are unsure of the exact chapter, say so in `context` and use the best approximation.
+
+4. **`context` is optional but valuable**. Use it when the quote's significance isn't obvious from the text alone. "Deutsch's inversion of the positivist demand for predictive certainty" is a better context than "A great quote from the book."
+
+### For chapters
+
+1. **Cover every chapter**. Do not cherry-pick; a partial chapter list is worse than none. If you do not know the full chapter list, stop and request the book's table of contents.
+
+2. **`keyIdea` is the one sentence the reader should remember if they forget everything else in the chapter.** Not "What this chapter is about" — *what the chapter argues*.
+
+3. **`summary` is 2–4 sentences.** What is the chapter's argument, evidence, and how does it advance the book? Not a scene-by-scene recap for fiction; for non-fiction, never.
+
+4. **Use the exact chapter title** as the book prints it. If the book uses colons, em-dashes, or sub-titles, preserve them.
+
+## Quality rails
+
+- **Never fabricate.** If you cannot verify a quote or chapter title, say so. Better to return 10 verified quotes than 20 half-real ones.
+- **Never paraphrase as quote.** If you cannot find the exact wording, use `context` to note it's a paraphrase — never put paraphrase in `text`.
+- **Respect the book's tone.** If the author is technical, keep the technical language. Do not "simplify" their voice.
+- **No spoilers for fiction.** For non-fiction: spoil freely; the ideas are the product.
+- **No AI-sounding phrases.** Blacklist: delve, dive into, it's worth noting, certainly, absolutely.
+
+## Process
+
+1. **Acknowledge inputs** — state what book, what mode, what source.
+2. **Plan coverage** — if `quotes` mode: aim for spread across chapters. If `chapters` mode: confirm total chapter count.
+3. **Extract** — produce the data, matching the types exactly.
+4. **Verify self** — re-read your output. Does every quote stand alone? Does every chapter's keyIdea survive removal of the summary?
+5. **Return** — structured JSON matching the types. The caller merges it into `data/book-reviews.ts`.
+
+## Report format
+
+Return the structured output as a markdown-fenced TypeScript block:
+
+````markdown
+## Book Distiller — Result for {title} by {author}
+
+- Mode: {mode}
+- Source: {source or "knowledge-only"}
+- Quotes extracted: N
+- Chapters extracted: N
+- Coverage: {which chapters / how spread}
+- Verification notes: {anything uncertain}
+
+```ts
+quotes: [
+  { text: "...", chapter: "Chapter 1 — Intro", context: "..." },
+  // ...
+],
+chapters: [
+  { number: 1, title: "...", keyIdea: "...", summary: "..." },
+  // ...
+],
+```
+````
+
+The orchestrator (`/library-deepen`) reads this, merges into the target entry, and runs the type-check.
+
+## What you do NOT do
+
+- Do not write to `data/book-reviews.ts` directly — return data, caller merges.
+- Do not build the template.
+- Do not handle cover images (that's `/library-add`).
+- Do not recommend related books (that's `/library-research`).
+- Do not make pages live or ship — stay in your lane.
+
+## Integration
+
+- Called by: `/library-deepen` command
+- Skill that documents the full workflow: `library-os`
+- Type definitions: `app/books/types.ts` (`BookQuote`, `BookChapterSummary`)

--- a/.claude/commands/library-add.md
+++ b/.claude/commands/library-add.md
@@ -1,0 +1,99 @@
+---
+description: Add a new book to the Library OS. Creates a minimum-viable entry in data/book-reviews.ts with required fields, then offers to deepen it via /library-deepen.
+---
+
+# /library-add — Add a Book to the Library
+
+You are the **Library OS Ingestion agent**. Your job is to take a book title (and optionally author / ISBN / Amazon URL) and produce a new, well-formed entry in `data/book-reviews.ts`.
+
+## Input
+
+Arguments: `/library-add "Book Title" [by Author] [--isbn=XXXX] [--amazon=URL]`
+
+If only the title is given, infer the author and ISBN. If ambiguous (multiple editions, multiple authors of same title), ask once, then proceed.
+
+## Execution
+
+### Step 1 — Validate schema
+
+Read `app/books/types.ts` to confirm the current `BookReview` interface shape. Required fields are:
+
+- `slug` (kebab-case from title)
+- `title`
+- `author`
+- `coverImage` (path `/images/library/{slug}.jpg`)
+- `rating` (1–5, default 5 unless user overrides)
+- `reviewDate` (today's ISO date)
+- `categories` (2–3 from existing color-mapped set — check `app/library/page.tsx` for allowed categories)
+- `readingTime` (estimate: short book "5 min", dense "8 min")
+- `keyInsights` (exactly 5 items, each 1–2 sentences, non-overlapping)
+- `bestFor` (3–4 audience descriptors)
+
+Optional fields to populate when confident:
+- `amazonUrl`
+- `relatedBook` (slug from `booksRegistry` — one of `self-development`, `manifestation`, `spartan-mindset`, `imagination`, `great-transition`, etc.)
+- `publicationYear`
+- `tldr` (1–2 sentences answering "what is this book about?" — used by JSON-LD, AEO)
+- `faq` (4–5 Q&A pairs — common questions about the book)
+
+### Step 2 — Pull the cover (if confident on ISBN)
+
+Try OpenLibrary first:
+
+```bash
+mkdir -p public/images/library
+curl -sL -o public/images/library/{slug}.jpg "https://covers.openlibrary.org/b/isbn/{ISBN}-L.jpg?default=false"
+file public/images/library/{slug}.jpg  # verify JPEG
+```
+
+If the file is 0 bytes or not JPEG, do not set `hasCover: true`. The template falls back to the letter-gradient automatically.
+
+### Step 3 — Write the entry
+
+Append to the `bookReviews` array in `data/book-reviews.ts`. Match the style and quote-escaping of existing entries exactly.
+
+### Step 4 — Type-check
+
+Run scoped type-check to confirm the addition compiles:
+
+```bash
+npx tsc --noEmit app/library/page.tsx app/library/\[slug\]/page.tsx data/book-reviews.ts
+```
+
+### Step 5 — Offer the deepen
+
+Print:
+
+```
+Entry created: /library/{slug}
+Baseline populated:
+  - TL;DR: ✓
+  - Key insights: 5
+  - Best For: N
+  - FAQ: N
+  - Cover: {yes|no}
+
+Run /library-deepen {slug} to add quotes, chapters, related reading, and videos.
+```
+
+## Content quality standards
+
+- **No AI-sounding phrases** — blacklisted: "delve", "dive into", "it's worth noting", "certainly", "absolutely", "let's explore"
+- **Lead with specifics, not generalities** — every insight should name a concrete idea, not a vibe
+- **TL;DR is the book's thesis in 1–2 sentences** — if you can't state it, re-read
+- **FAQ answers the reader's actual question first, then gives context** — never restate the question
+- **Categories must match the color map** — Self-Development, Habits, Psychology, Productivity, Focus, Mindset, Fitness, Fiction, Philosophy, Stoicism, Creativity, Wealth, Classic, Writing, Career, Spirituality, Memoir, Autobiography, Discipline
+
+## Example
+
+```
+/library-add "The Beginning of Infinity" by David Deutsch --isbn=0143121359
+```
+
+→ creates `/library/the-beginning-of-infinity` with author, 5 insights, FAQ, cover, TL;DR. Ready for `/library-deepen`.
+
+## Integration
+
+- Part of the Library OS workflow: `/library-add` → `/library-deepen` → `/library-research` → ship
+- Output format matches `app/books/types.ts::BookReview`
+- Paired with skill `library-os` for the full workflow context

--- a/.claude/commands/library-deepen.md
+++ b/.claude/commands/library-deepen.md
@@ -1,0 +1,93 @@
+---
+description: Upgrade a book entry from review-depth to deep-dive hub — extract quotes, distill chapters, populate the TOC-worthy fields.
+---
+
+# /library-deepen — Deep-Dive an Existing Book
+
+You are the **Library OS Deep-Dive agent**. Your job is to take an existing library entry and upgrade it into a single-page knowledge hub by populating `quotes`, `chapters`, and triggering the research agent for `continueReading` + `videos`.
+
+## Input
+
+Arguments: `/library-deepen {slug}` (e.g. `/library-deepen atomic-habits`)
+
+Optionally: `--source=path/to/book.pdf` or `--source=path/to/notes.md` to base extraction on the actual text.
+
+## Execution
+
+### Step 1 — Load the entry
+
+Read `data/book-reviews.ts`, find the entry by slug. If the book does not exist yet, run `/library-add` first.
+
+### Step 2 — Curate quotes
+
+Target: **10–20 quotes** that are:
+- **Memorable** — short enough to quote (ideally under 30 words)
+- **Load-bearing** — carry a key idea, not just rhetoric
+- **Distributed** — spread across the book, not clustered in one chapter
+- **Attributable** — each ends with a `chapter` reference in the data
+
+Delegate to the `book-distiller` subagent with the book title + author + source (if provided) + target count. The subagent returns `BookQuote[]` in the exact shape of the type.
+
+**Each quote MUST include:**
+- `text` — the quote verbatim (or the best English translation)
+- `chapter` — `"Chapter 3 — Problem-Solving"` format (include both number and title)
+- `context` (optional) — one sentence framing *why* this quote matters
+
+### Step 3 — Distill chapters
+
+Target: **every chapter of the book**, no exceptions. Each chapter gets:
+- `number` — 1-indexed
+- `title` — exact chapter title
+- `keyIdea` — one sentence, the chapter's thesis
+- `summary` — 2–4 sentences, what the chapter argues
+
+Delegate to `book-distiller` with `mode: 'chapters'`. Returns `BookChapterSummary[]`.
+
+### Step 4 — Offer research handoff
+
+Print:
+
+```
+Quotes added: N
+Chapters added: N
+
+Run /library-research {slug} to populate continueReading + videos.
+```
+
+### Step 5 — Type-check + preview
+
+```bash
+npx tsc --noEmit data/book-reviews.ts
+```
+
+Optionally, fetch the rendered page in dev to sanity-check: the TOC should now list Quotes + Chapter-by-Chapter sections.
+
+## Quality standards
+
+- **Quotes over paraphrases**. A good quote is hard to vary. If the quote becomes a paraphrase, it's not a quote — drop it or find the real passage.
+- **Chapters are a compass, not a recap**. The reader has read (or will read) the book — `keyIdea` is what they should remember *if they forget everything else in the chapter*.
+- **No spoilers for fiction**. For non-fiction, spoil freely — the value is in the ideas, not the surprise.
+- **Attribute carefully**. For paraphrased ideas from a chapter, use `context` to note "Paraphrase of Chapter X's argument" rather than putting it in `text` as a fake quote.
+
+## Delegation pattern
+
+This command is a thin orchestrator. The actual extraction work happens in the `book-distiller` subagent, which has the deeper prompt and source-handling. `/library-deepen` provides:
+
+1. The slug → finds the entry
+2. The shape → tells the subagent what fields to return
+3. The merge → writes the result back to `data/book-reviews.ts`
+
+## Example
+
+```
+/library-deepen fabric-of-reality
+```
+
+→ Produces 16 quotes + 14 chapters in `data/book-reviews.ts`, updates `app/library/page.tsx` has TOC showing "02 · Quotes (16)" and "03 · Chapter-by-Chapter (14)".
+
+## Integration
+
+- Upstream: `/library-add` (prerequisite)
+- Downstream: `/library-research` (continues the workflow)
+- Skill: `library-os` (the workflow context)
+- Subagent: `book-distiller` (does the extraction)

--- a/.claude/commands/library-research.md
+++ b/.claude/commands/library-research.md
@@ -1,0 +1,113 @@
+---
+description: Enrich a book entry with curated "Continue Reading" recommendations and "Go Deeper" videos. Final step in the Library OS deepen workflow.
+---
+
+# /library-research — External Context for a Book
+
+You are the **Library OS Research agent**. Your job is to populate `continueReading` (external books that pair with this one) and `videos` (talks, interviews, lectures that extend the book's ideas) on an existing library entry.
+
+## Input
+
+Arguments: `/library-research {slug}` (e.g. `/library-research atomic-habits`)
+
+## Execution
+
+### Step 1 — Understand the book's intellectual neighborhood
+
+Read the existing entry. The `categories`, `keyInsights`, `tldr`, and `chapters` already define what territory this book lives in. Your job is to map the surrounding territory.
+
+### Step 2 — Curate `continueReading` (6–8 items)
+
+For each recommendation, answer: **"Why does this book pair with the source book?"**
+
+Target distribution:
+- **1–2 foundational** — the intellectual ancestors the source book builds on (e.g. Popper for Deutsch, Gerber for Michalowicz)
+- **1–2 contemporaries** — books making similar arguments from a different angle
+- **1–2 contrarians** — books that challenge or extend the source book's claims (Penrose vs. Deutsch on computation)
+- **1–2 practical** — books that apply the source book's ideas to a specific domain
+- **1 adjacent** — a book from a different field that unexpectedly illuminates the source
+
+**Each item:**
+- `title`, `author` — required, exact
+- `reason` — 1–2 sentences explaining the pairing. Not a summary of the recommended book — a *connection*.
+- `url` — canonical Amazon or publisher link, optional but preferred
+
+**Never recommend algorithmically**. Every item must earn its place by reason. If you cannot articulate the pairing in one sentence, it does not belong.
+
+### Step 3 — Curate `videos` (3–6 items)
+
+Priorities:
+1. **The author in long-form** — interview/lecture/podcast with the book's author. Often the richest context.
+2. **The author's canonical talk** — TED, keynote, summary talk. 10–30 min entry points.
+3. **Critical engagement** — a thinker who takes the book seriously and argues with it.
+4. **Domain explainer** — a short overview for readers who want the TL;DR before committing.
+
+**Each item:**
+- `title`, `creator` — required
+- `url` — YouTube URL preferred. If uncertain whether a specific video exists, use a YouTube search URL (`https://www.youtube.com/results?search_query=...`) rather than inventing a URL
+- `description` — 1–2 sentences: what the viewer learns
+- `duration` — approximate, optional
+- `kind` — one of `interview`, `lecture`, `talk`, `explainer`, `summary`
+
+### Step 4 — Verify
+
+For each URL, confirm:
+- If direct YouTube URL: the channel / video title matches what you claimed
+- If YouTube search URL: the search query returns sensible results (just check shape)
+- If Amazon URL: the ISBN pattern matches the book (no fake links)
+
+**Never fabricate URLs.** Better to use a search query than a dead direct link.
+
+### Step 5 — Merge and ship
+
+Write the results into `data/book-reviews.ts` against the slug's entry. Type-check. Print a summary:
+
+```
+Continue Reading: N items
+Videos: N items
+
+Deep-dive complete for {slug}. See /library/{slug} — TOC now has all 7 sections.
+```
+
+## Quality standards
+
+### continueReading
+- **Reason, not blurb.** "Popper is where Deutsch's epistemology comes from" beats "A classic of 20th-century philosophy of science"
+- **No padding.** If you only have 4 strong pairings, ship 4. Weak recommendations erode trust in the 4 strong ones.
+- **Disclose contrarians honestly.** "Penrose argues consciousness is non-computable, directly contradicting Deutsch's Turing principle" is more valuable than pretending everyone agrees.
+
+### videos
+- **Watch-worthy, not algorithmic.** If the top YouTube result for the author is a low-quality reaction video, use a search URL and let the user filter.
+- **Entry points matter more than comprehensiveness.** A 15-minute TED talk that opens the door beats a 3-hour podcast most people won't finish.
+- **Describe the value, not the video.** "Naval's framing of why 'problems are soluble' is a physics claim, not a slogan" beats "Naval interviews Deutsch about epistemology."
+
+## Integration
+
+- Upstream: `/library-deepen` (typically runs right after)
+- Skill: `library-os`
+- Data written into: `data/book-reviews.ts` (same file as `/library-add` and `/library-deepen`)
+
+## Example output shape
+
+```ts
+continueReading: [
+  {
+    title: 'The Beginning of Infinity',
+    author: 'David Deutsch',
+    reason: "Deutsch's 2011 sequel. If Fabric of Reality is the synthesis, Beginning of Infinity is the mature worldview — 'good explanations', the reach of knowledge, and the ethics of progress.",
+    url: 'https://www.amazon.com/Beginning-Infinity-.../dp/0143121359',
+  },
+  // ...
+],
+videos: [
+  {
+    title: 'David Deutsch — A new way to explain explanation',
+    creator: 'TED',
+    url: 'https://www.ted.com/talks/david_deutsch_a_new_way_to_explain_explanation',
+    description: "Deutsch's canonical 16-minute talk. The 'hard-to-vary' criterion for good explanations, distilled. Best single-video entry point to his worldview.",
+    duration: '16m',
+    kind: 'talk',
+  },
+  // ...
+],
+```

--- a/.claude/skills/library-os/SKILL.md
+++ b/.claude/skills/library-os/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: library-os
+description: Library OS — the persistent digital library system. Use when adding a book, deepening an existing review, extracting insights from handwritten notes / highlights / photos, or when the user wants to build their own library on their site. Handles the full workflow from capture to publish.
+---
+
+# Library OS
+
+**The open-source Library Intelligence System.** Captures everything you read into a permanent, intelligent, citation-ready knowledge library on your own website.
+
+## When to use this skill
+
+- User mentions adding a book, book review, reading list, library
+- User shares handwritten notes, book highlights, Kindle exports, or a photo of notes
+- User says "I just finished [book]" or "let me capture this book"
+- User asks about the book system, /library/*, or wants to port it to another site
+- User wants to deepen a shallow review into a hub page
+
+## Core philosophy
+
+1. **Own your library.** Kindle highlights die in Kindle. Notion docs scatter. A library on your own site, in git, becomes a permanent asset that compounds for decades.
+2. **Data schema is the spine.** The template is interchangeable; the `BookReview` type + its sub-types are the interoperable core. Port to any Next.js, Astro, SvelteKit, or even static HTML.
+3. **Structured, not scraped.** Every book is curated — quotes carry chapter references, chapter summaries carry key ideas, related reading carries a *reason*, not a category tag.
+4. **AEO-first.** Every book page emits BreadcrumbList + Article + Review + FAQPage + Quotation schema. Citation surface is the product.
+5. **Repeatable, not bespoke.** One data schema, one template, one command pipeline. Every new book follows the same path. No snowflakes.
+
+## The workflow (canonical)
+
+```
+CAPTURE ──────► EXTRACT ──────► ENRICH ──────► PUBLISH
+   │                │                │              │
+   ▼                ▼                ▼              ▼
+Photo, notes,   quotes[]      continueReading[]   /library/{slug}
+Kindle export,  chapters[]    videos[]            (live, SEO+AEO)
+voice memo      tldr, faq     + schema
+```
+
+**Step 1 — CAPTURE**
+The user provides the raw signal: a book title, a handwritten note photo, a highlights export, a voice memo. If a photo, extract text via vision. If a file, read it.
+
+**Step 2 — EXTRACT**
+Run `/library-add` to create the baseline entry (title, author, categories, 5 key insights, best-for, FAQ, TL;DR, cover). Then run `/library-deepen` to populate `quotes` and `chapters` via the `book-distiller` subagent.
+
+**Step 3 — ENRICH**
+Run `/library-research` to populate `continueReading` (external books with why-they-pair rationale) and `videos` (talks, interviews, lectures).
+
+**Step 4 — PUBLISH**
+Commit, sync to production repo, ship. Page goes live at `/library/{slug}` with the full deep-dive hub: TL;DR, TOC, insights, quotes, chapters, FAQ, continue-reading, videos, related-own-book, Amazon CTA.
+
+## The three slash commands
+
+| Command | Purpose | Writes to |
+|---|---|---|
+| `/library-add` | Create a new entry from just a title | `data/book-reviews.ts`, `public/images/library/` |
+| `/library-deepen` | Add quotes + chapters to existing entry | `data/book-reviews.ts` |
+| `/library-research` | Add continueReading + videos | `data/book-reviews.ts` |
+
+Run in order. Each is idempotent — running `/library-deepen` twice just refines the existing quotes/chapters, it does not duplicate.
+
+## The subagent
+
+**book-distiller** — the extraction specialist. Given a book + (optional) source text, returns structured `quotes[]` and `chapters[]` matching the exact type shape. Delegated to by `/library-deepen` so the main conversation stays thin.
+
+See `.claude/agents/book-distiller.md` for the agent prompt.
+
+## The data schema (always the source of truth)
+
+Located at `app/books/types.ts`:
+
+```ts
+interface BookReview {
+  // Identity
+  slug, title, author, coverImage, rating, reviewDate, categories, readingTime
+
+  // Core content (required)
+  keyInsights: string[]  // exactly 5
+  bestFor: string[]      // 3-4
+
+  // AEO core (optional, strongly recommended)
+  tldr?: string
+  faq?: Array<{q, a}>
+  publicationYear?: number
+
+  // Deep-dive hub (optional — the progressive depth layer)
+  quotes?: BookQuote[]                // curated passages
+  chapters?: BookChapterSummary[]     // number, title, keyIdea, summary
+  continueReading?: RelatedReadingItem[]  // with reason, not algorithm
+  videos?: BookVideo[]                // kind, duration, description
+
+  // Wiring
+  amazonUrl?: string
+  relatedBook?: string     // slug from booksRegistry — links to our own books
+  hasCover?: boolean       // gates the next/image render
+}
+```
+
+Books without the deep-dive fields render as review-depth. Books with all fields render as full knowledge hubs. One template, progressive depth.
+
+## Cross-AI / cross-tool portability
+
+The intelligence is in the **schema + workflow**, not in any specific AI tool. The same pattern works with:
+
+- **Claude Code (native)** — the three slash commands + subagent + skill are defined here
+- **ChatGPT / Claude.ai (web)** — paste the extraction prompt from the command file, paste the book details, get structured output, paste into `data/book-reviews.ts`
+- **Codex / Cursor / Gemini CLI** — read `.claude/commands/library-*.md` as plain instructions, execute the steps
+- **Hand-roll** — the schema and template work without any AI. Manually curated libraries are valid.
+
+See `docs/cross-ai-guide.md` in the library-os repo for the prompt-paste versions.
+
+## Deployment targets
+
+The template is Next.js App Router (frankx.ai uses this). Adaptations:
+
+- **Astro** — Port `app/library/` to `src/pages/library/`, use `.astro` for layout. Data schema unchanged.
+- **SvelteKit** — `routes/library/+page.svelte`, data unchanged.
+- **Hugo** — static generation, the `BookReview[]` becomes frontmatter YAML in `content/library/*.md`.
+- **Plain HTML** — a small build script renders the data to static pages.
+
+The spine — `data/book-reviews.ts` as a typed array + the JSON-LD schema — is portable.
+
+## Index page contract
+
+The library index (`/library`) shows:
+- All reviews sorted by `reviewDate` DESC (newest first)
+- Cards with cover + title + author + star rating + top insight
+- "Deep-dive badge" on cards that have quotes/chapters/videos (e.g. "16 quotes · 14 chapters · 5 videos")
+- Category filter (optional, client-side)
+- CollectionPage + ItemList + BreadcrumbList JSON-LD
+
+## Detail page contract
+
+The detail page (`/library/{slug}`) renders, in order:
+1. Back link → `/library`
+2. Header: cover + title + author + stars + category chips
+3. TL;DR card (if `tldr`)
+4. Table of Contents (inline anchor nav, sections only shown when data present)
+5. Key Insights (5)
+6. Quotes Worth Remembering (if `quotes`)
+7. Chapter-by-Chapter accordion (if `chapters`)
+8. Best For
+9. FAQ accordion (if `faq`)
+10. Continue Reading grid (if `continueReading`)
+11. Go Deeper — Videos (if `videos`)
+12. "If You Liked This, Read Ours" (if `relatedBook` matches a slug in booksRegistry)
+13. Amazon CTA
+14. More from the Library (3 other reviews)
+
+All section IDs are anchor-linkable with `scroll-mt-24` for smooth jumps from the TOC.
+
+## Quality bar
+
+- **No AI-sounding phrases.** Blacklist: delve, dive into, it's worth noting, certainly, absolutely, in conclusion, let's explore.
+- **No fake URLs.** If uncertain about a specific video URL, use a YouTube search URL. Better a search than a dead link.
+- **No blurb-style recommendations.** Every `continueReading.reason` must state a *connection*, not a summary.
+- **No chapter fabrication.** If the book's chapter list is uncertain, stop and ask for the table of contents. Never invent chapters.
+- **Cover images from legitimate sources.** OpenLibrary (`covers.openlibrary.org/b/isbn/{ISBN}-L.jpg`) is fair-use for review purposes. Never scrape Amazon product images.
+
+## Git workflow
+
+Library changes live in the FrankX dev repo but deploy via the production repo (`frankxai/frankx.ai-vercel-website`). Standard pattern:
+
+1. Commit library changes in FrankX dev repo (scoped: `app/library/`, `app/books/types.ts`, `data/book-reviews.ts`, `public/images/library/`)
+2. Create isolated worktree from prod `origin/main`
+3. Sync those exact files into the worktree
+4. Commit in worktree, push branch, open PR
+5. Admin-merge after Vercel preview passes (CI will show pre-existing tech debt — ignore per issue #31)
+6. Verify live on frankx.ai
+
+## Related
+
+- `/library` → the live index
+- `/library/approach` → the showcase page explaining the system
+- GitHub: `library-os` repo → open-source template + docs
+- Companion skill: `book-publishing` (for authoring own books)


### PR DESCRIPTION
## Summary

Integrates **[Library OS](https://github.com/frankxai/library-os)** as a first-class ACOS plugin. Every ACOS user now gets the book-intelligence workflow out of the box.

Live reference at [frankx.ai/library](https://frankx.ai/library) (22 deep-dived books, 277 curated quotes with selection-share + per-quote OG-image cards + JSON quote API).

## What this adds

### 3 slash commands
- `.claude/commands/library-add.md` — Create a baseline library entry from just a book title
- `.claude/commands/library-deepen.md` — Populate `quotes[]` + `chapters[]` via `book-distiller` subagent
- `.claude/commands/library-research.md` — Add `continueReading[]` (with connection-reasons) + `videos[]`

### 1 skill
- `.claude/skills/library-os/SKILL.md` — Canonical workflow doc: capture → extract → enrich → publish, the five commitments, the data schema, cross-AI portability, deployment targets

### 1 subagent
- `.claude/agents/book-distiller.md` — Extraction specialist that returns `BookQuote[]` and `BookChapterSummary[]` from a title (or source PDF/highlights)

## Why it ships in ACOS

The Library OS workflow:
1. **Repeatable.** Same three commands turn any book into a permanent deep-dive page.
2. **Schema-first.** The `BookReview` TypeScript type is the spine; the template is interchangeable.
3. **Cross-AI.** The commands are plain-text prompts that work in ChatGPT, Cursor, Codex, Gemini — Claude Code is just the canonical implementation.
4. **AEO-first.** Per-quote permalinks, dynamic OG cards, FAQPage + Quotation schema. Every quote is an evergreen citation surface.

## How users invoke it

After installing ACOS:

```
/library-add "Atomic Habits" by James Clear
/library-deepen atomic-habits
/library-research atomic-habits
```

Three commands turn a book into 15+ curated quotes, every chapter distilled, 6 connection-reasoned related reads, 4 videos, FAQPage + Quotation JSON-LD, dedicated /q/{n} landing pages with auto-generated OG cards.

## Reference site

Full live implementation at [frankx.ai/library](https://frankx.ai/library). Open-source template at [github.com/frankxai/library-os](https://github.com/frankxai/library-os) (MIT, bootable Next.js — copy-paste or `git clone`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Library OS system with automated book ingestion, quote extraction, and chapter summarization capabilities.
  * Added new commands for managing book library entries, deepening existing entries with quotes and chapter summaries, and researching related content recommendations.
  * Enhanced book review workflow with structured metadata generation, cover sourcing, and content enrichment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->