### PR TITLE
feat(skills): agentic-builder-lab content pipeline skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ On non-Claude platforms, just describe what you want. Skills activate from conte
 
 ## Available Commands (35+)
 
-### Creation (9)
+### Creation (10)
 | Command | Description |
 |---------|-------------|
 | `/article-creator` | Guided blog article creation |
@@ -92,6 +92,7 @@ On non-Claude platforms, just describe what you want. Skills activate from conte
 | `/products-creation` | Digital products, courses, templates |
 | `/author-team` | Book writing with specialist team |
 | `/hook` | Multi-dimensional content hook engineering |
+| `/build-log` | Convert a build session into MDX log, LinkedIn draft, demo brief, diagram, and prompt-pack entry (agentic-builder-lab skill) |
 
 ### Strategy (6)
 | Command | Description |

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "dev:all": "npm run dev --workspaces",
     "postinstall": "echo '\\n🚀 Agentic Creator OS installed! Run: ./install.sh\\n'",
     "publish": "npm run build:all && npm publish",
-    "version:bump": "npm version $npm_config_version && git push && git push --tags"
+    "version:bump": "npm version $npm_config_version && git push && git push --tags",
+    "lint": "node scripts/lint.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * ACOS lint — lightweight integrity checks for the skill substrate.
+ *
+ * Hard errors (exit 1): malformed JSON in registry.json or any skills/**.json.
+ * Warnings (exit 0): SKILL.md files missing YAML frontmatter (name/description).
+ *
+ * Kept intentionally dependency-free so it runs under `npm run lint` in CI
+ * without a node_modules install step beyond what build:all already provides.
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+let errors = 0
+let warnings = 0
+
+function walk(dir, predicate, out = []) {
+  if (!existsSync(dir)) return out
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.git') continue
+    const full = join(dir, entry)
+    const s = statSync(full)
+    if (s.isDirectory()) walk(full, predicate, out)
+    else if (predicate(entry)) out.push(full)
+  }
+  return out
+}
+
+// 1. registry.json must be valid JSON with the expected shape.
+const registryPath = join(ROOT, 'skills', 'registry.json')
+if (existsSync(registryPath)) {
+  try {
+    const reg = JSON.parse(readFileSync(registryPath, 'utf8'))
+    for (const key of ['version', 'categories', 'skills']) {
+      if (!(key in reg)) {
+        console.error(`✗ registry.json missing required key: ${key}`)
+        errors++
+      }
+    }
+  } catch (err) {
+    console.error(`✗ registry.json is not valid JSON: ${err.message}`)
+    errors++
+  }
+} else {
+  console.error('✗ skills/registry.json not found')
+  errors++
+}
+
+// 2. Every JSON file under skills/ must parse.
+for (const f of walk(join(ROOT, 'skills'), (n) => n.endsWith('.json'))) {
+  try {
+    JSON.parse(readFileSync(f, 'utf8'))
+  } catch (err) {
+    console.error(`✗ invalid JSON: ${f.replace(ROOT + '/', '')} — ${err.message}`)
+    errors++
+  }
+}
+
+// 3. SKILL.md frontmatter — warn only (pre-existing skills may lack it).
+const skillMds = walk(join(ROOT, 'skills'), (n) => n === 'SKILL.md')
+for (const f of skillMds) {
+  const text = readFileSync(f, 'utf8')
+  const rel = f.replace(ROOT + '/', '')
+  if (!text.startsWith('---')) {
+    console.warn(`⚠ ${rel}: missing YAML frontmatter`)
+    warnings++
+    continue
+  }
+  const fm = text.slice(3, text.indexOf('---', 3))
+  if (!/\bname\s*:/.test(fm)) {
+    console.warn(`⚠ ${rel}: frontmatter missing 'name'`)
+    warnings++
+  }
+  if (!/\bdescription\s*:/.test(fm)) {
+    console.warn(`⚠ ${rel}: frontmatter missing 'description'`)
+    warnings++
+  }
+}
+
+console.log(
+  `\nACOS lint: ${skillMds.length} skills checked · ${errors} error(s) · ${warnings} warning(s)`
+)
+
+process.exit(errors > 0 ? 1 : 0)

--- a/skills/projects/agentic-builder-lab/SKILL.md
+++ b/skills/projects/agentic-builder-lab/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: Agentic Builder Lab
+description: Convert a single build session into MDX build-log entry, LinkedIn draft, demo brief, Mermaid diagram, and a reusable prompt. Use when logging a public build or running the content flywheel for the /agentic-builder-lab and /build pages on frankx.ai.
+version: 0.1.0
+triggers:
+  - "log a build"
+  - "build session log"
+  - "agentic-builder-lab"
+  - "/build-log"
+inputs:
+  required: [build_name, status, stack, key_learning]
+  optional: [demo_url, repo_url, day_number, outcome_metric, slug]
+outputs:
+  - content/builds/[slug].mdx
+  - drafts/linkedin/[slug].md
+  - drafts/demos/[slug]-brief.md
+  - drafts/diagrams/[slug].mmd
+  - skills/projects/agentic-builder-lab/resources/prompt-pack/[slug].md
+dependencies: [frankx-brand]
+voice_override: resources/voice-spec.md
+---
+
+# Agentic Builder Lab
+
+One build session, five artifacts. This skill takes the receipts from a real build and produces the content stack that ships to frankx.ai.
+
+## The flywheel
+
+A single build session produces:
+
+1. **MDX build-log entry** — long-form record at `content/builds/[slug].mdx` (rendered by `/agentic-builder-lab/[slug]` on the frankx.ai site).
+2. **LinkedIn draft** — short post that points back to the build log.
+3. **Demo brief** — 60-90s video script with shot list.
+4. **Mermaid diagram** — the architecture or agent flow, ready to embed.
+5. **Reusable prompt** — one artifact from the build added to the prompt pack so the next builder can copy it.
+
+The point is leverage. One session, five published surfaces. No artifact is decorative — each one points to the next.
+
+## Voice override
+
+This skill depends on `frankx-brand`, but **overrides its default studio voice** for every output it produces. The override is loaded from `resources/voice-spec.md` after `frankx-brand` is loaded, so the override wins.
+
+The override rules in short:
+
+- Technical authority. Results first, claims never.
+- No spiritual, consciousness, or transformation language.
+- No exclamation marks. No hype adjectives.
+- Lead with what was built, the tool, and the outcome.
+- Show failures honestly — humility is on-brand.
+
+Banned terms (lint at exit): `soul`, `awaken`, `transformation`, `alignment`, `journey`, `intentional`, `sacred`, `energy`, `vibration`, `frequency`, `studio` (as metaphor), `elevate` (as metaphor), `unlock` (as metaphor).
+
+Encouraged terms: `architect`, `agent`, `verification`, `orchestration`, `stack`, `primitive`, `harness`, `scaffold`, `ship`, `repo`, `PR`, `eval`.
+
+Full spec: see `resources/voice-spec.md`.
+
+## How the skill runs
+
+### Step 1 — Load voice override
+
+1. Read `resources/voice-spec.md`.
+2. Treat its rules as binding for every artifact this skill writes.
+3. If `frankx-brand` was loaded earlier in the session, its studio voice is now suppressed for outputs of this skill.
+
+### Step 2 — Collect inputs
+
+Required fields:
+
+- `build_name` — short label (becomes the title).
+- `status` — one of `live`, `shipping`, `wip`, `paused`, `archived`.
+- `stack` — list of tools and what each one does in the build.
+- `key_learning` — the one thing the builder would tell another builder.
+
+Optional fields:
+
+- `demo_url` — live demo URL.
+- `repo_url` — public repo.
+- `day_number` — if this is part of a build-in-public counter.
+- `outcome_metric` — one quantifiable result (latency, cost, users, PRs merged).
+- `slug` — kebab-case slug. If not provided, derive from `build_name`.
+
+If any required field is missing, ask the user for it in one batched message. Do not invent values. Do not proceed until all four required fields are filled.
+
+### Step 3 — Generate the five artifacts
+
+Load each template from `resources/` and fill it in:
+
+| Output | Template | Destination |
+|---|---|---|
+| MDX build log | `resources/mdx-template.md` | `content/builds/[slug].mdx` |
+| LinkedIn draft | `resources/linkedin-template.md` | `drafts/linkedin/[slug].md` |
+| Demo brief | `resources/demo-brief-template.md` | `drafts/demos/[slug]-brief.md` |
+| Mermaid diagram | `resources/diagram-prompt.md` | `drafts/diagrams/[slug].mmd` |
+| Prompt pack entry | `resources/prompt-pack-conventions.md` | `skills/projects/agentic-builder-lab/resources/prompt-pack/[slug].md` |
+
+The MDX file is the canonical artifact. The other four reference it.
+
+### Step 4 — Lint
+
+After all files are written, grep each one for banned terms. If any banned term appears, rewrite that artifact before exit. Suggested check:
+
+```bash
+BANNED="soul|awaken|transformation|alignment|journey|intentional|sacred|energy|vibration|frequency"
+grep -InE "\\b($BANNED)\\b" content/builds/[slug].mdx drafts/linkedin/[slug].md drafts/demos/[slug]-brief.md
+```
+
+Lint must pass on a clean exit.
+
+### Step 5 — Report
+
+Print the five file paths and a one-line summary of each. Do not push, do not commit. The caller decides what to ship.
+
+## Example invocation
+
+```
+User: /build-log
+
+> build_name: Antigravity Codex Bridge
+> status: shipping
+> stack:
+>   - Antigravity: agent harness
+>   - Codex CLI: parallel verification
+>   - Claude Code: PR review
+>   - Vercel: deploy
+> key_learning: Two agents disagreeing on the same PR catches more bugs than one agent running twice.
+> day_number: 14
+> outcome_metric: 3 PRs shipped in one afternoon
+> demo_url: https://example.com/demo
+> repo_url: https://github.com/frankxai/example
+```
+
+Skill produces:
+
+```
+content/builds/antigravity-codex-bridge.mdx
+drafts/linkedin/antigravity-codex-bridge.md
+drafts/demos/antigravity-codex-bridge-brief.md
+drafts/diagrams/antigravity-codex-bridge.mmd
+skills/projects/agentic-builder-lab/resources/prompt-pack/antigravity-codex-bridge.md
+```
+
+## Files in this skill
+
+```
+agentic-builder-lab/
+├── SKILL.md                                 ← this file
+└── resources/
+    ├── voice-spec.md                        ← voice override (load first)
+    ├── mdx-template.md                      ← build-log MDX scaffold
+    ├── linkedin-template.md                 ← 9 LinkedIn post combos
+    ├── demo-brief-template.md               ← 60-90s video brief
+    ├── diagram-prompt.md                    ← 3 Mermaid diagram templates
+    ├── prompt-pack-conventions.md           ← how to add a prompt
+    └── prompt-pack/
+        └── example-agents-md.md             ← starter prompt: AGENTS.md template
+```
+
+## Notes for the model running this skill
+
+- Read `voice-spec.md` before generating any artifact. Re-check it before the lint step.
+- If the user already has a build log at `content/builds/[slug].mdx`, ask whether to update it or write a new entry with a different slug.
+- The prompt pack is cumulative — never overwrite an existing entry without asking.
+- The MDX frontmatter must validate against the schema in `mdx-template.md`. If any field is missing, fall back to `null`, not an empty string.

--- a/skills/projects/agentic-builder-lab/resources/demo-brief-template.md
+++ b/skills/projects/agentic-builder-lab/resources/demo-brief-template.md
@@ -1,0 +1,144 @@
+# Demo Brief Template — 60-90s Video
+
+A 60-90 second screen demo of the build. Output goes to `drafts/demos/[slug]-brief.md`. Hand this brief to the editor or read it yourself if you're doing the recording.
+
+## Constraints
+
+- Total runtime: 60-90 seconds.
+- No exclamation marks in the script.
+- No banned terms from `voice-spec.md`.
+- Lead with the claim, end with the link.
+- Screen capture is the hero. Talking head is optional, max 10% of frame time.
+
+## Timing skeleton
+
+| Beat | Time | Job |
+|---|---|---|
+| Hook | 0-5s | One-sentence claim. The reason to keep watching. |
+| Setup | 5-20s | What we built and the stack. Three tools max named. |
+| Demo | 20-60s | The actual screen recording. The receipt. |
+| What broke + worked | 60-80s | Honest pass. Name one failure and one win. |
+| CTA | 80-90s | Where to read the full build log. |
+
+## Brief template
+
+````markdown
+# Demo Brief — <build name>
+
+**Slug:** <slug>
+**Runtime target:** 60-90s
+**Status of the build:** <live | shipping | wip | paused | archived>
+**Link to full build log:** https://frankx.ai/agentic-builder-lab/<slug>
+
+## One-line claim
+
+<The single sentence that opens the video. This is also the title of the YouTube short or the LinkedIn video caption.>
+
+## Voiceover script
+
+### 0-5s — Hook
+
+> <One sentence. Same as the claim. Read at normal pace.>
+
+### 5-20s — Setup
+
+> <Two to three sentences. What we built, the stack (name three tools max), the outcome metric.>
+
+### 20-60s — Demo
+
+> <Voiceover paced against the screen recording. Two or three beats max. Each beat names what's on screen and why it matters.>
+
+Beat 1: <what's on screen> — <why it matters>
+Beat 2: <what's on screen> — <why it matters>
+Beat 3: <what's on screen> — <why it matters>
+
+### 60-80s — What broke and what worked
+
+> <One sentence on the failure. One sentence on the win. Honest, specific.>
+
+### 80-90s — CTA
+
+> <One sentence. Send them to the build log.>
+
+Read: "Full write-up at frankx dot AI slash agentic-builder-lab slash <slug>."
+
+## Shot list
+
+| # | Shot | Source | Duration | Notes |
+|---|---|---|---|---|
+| 1 | Title card with claim | Static graphic | 0-3s | Lower-third with slug |
+| 2 | Stack diagram | `drafts/diagrams/<slug>.mmd` rendered | 3-8s | Mermaid render, 720p min |
+| 3 | Terminal: agent harness running | Screen capture | 8-25s | Trim dead time |
+| 4 | Side-by-side: verifier agents on the same diff | Screen capture | 25-45s | Use a real PR diff |
+| 5 | Preview deploy URL hit | Browser capture | 45-55s | Show the live endpoint |
+| 6 | What broke screen | Static slide with bullet | 55-70s | Be specific |
+| 7 | CTA card | Static graphic | 70-90s | Build log URL + QR code |
+
+## Recording notes
+
+- Resolution: 1920x1080 minimum, 30fps.
+- Vertical reframe (1080x1920) needed for Shorts. Plan shot composition with both crops in mind — keep critical content in the center third.
+- Audio: condenser mic if possible. No music bed for the first 10 seconds — let the claim land dry.
+- Cursor highlights on terminal moves. Default cursor is too small for mobile playback.
+- No B-roll of typing. Hands on keyboard is filler. Stay on the screen.
+
+## Captions
+
+Burn captions on all builds. Half the audience watches muted. Match the voiceover script exactly. Two lines max per card, sans-serif, high contrast.
+
+## Thumbnail brief
+
+- Stack diagram on the left.
+- Outcome metric on the right in 60pt+ type.
+- Build name in a header.
+- No face. The receipt is the hero.
+
+## QA pass before export
+
+- [ ] Runtime is 60-90s.
+- [ ] Captions match the voiceover.
+- [ ] No banned terms in the script.
+- [ ] What broke section names a specific failure.
+- [ ] CTA URL is correct.
+- [ ] Audio levels are normalized (-16 LUFS for social).
+- [ ] Vertical crop tested if shipping to Shorts.
+
+## Example (filled for `antigravity-codex-bridge`)
+
+````markdown
+# Demo Brief — Antigravity Codex Bridge
+
+**Slug:** antigravity-codex-bridge
+**Runtime target:** 75s
+**Status of the build:** shipping
+**Link to full build log:** https://frankx.ai/agentic-builder-lab/antigravity-codex-bridge
+
+## One-line claim
+
+Two agents reviewed every PR. We shipped three of them in one afternoon.
+
+## Voiceover script
+
+### 0-5s — Hook
+
+> Two agents reviewed every PR. We shipped three of them in one afternoon.
+
+### 5-20s — Setup
+
+> The stack is Antigravity, Codex CLI, and Claude Code. Antigravity opens the PRs. Codex and Claude both review the diff. The PR only merges when both agents pass.
+
+### 20-60s — Demo
+
+Beat 1: Terminal — Antigravity opening a PR with a real feature commit.
+Beat 2: Split screen — Codex CLI returns a fast verdict on style. Claude Code returns a slower semantic verdict.
+Beat 3: GitHub UI — both checks green, merge button enabled, click to merge.
+
+### 60-80s — What broke and what worked
+
+> What worked: two agents disagreeing caught four bugs single-agent review missed. What broke: the loop deadlocked once until we added a 60-second timeout on verifier prompts.
+
+### 80-90s — CTA
+
+> Full write-up at frankx dot AI slash agentic-builder-lab slash antigravity-codex-bridge.
+````
+````

--- a/skills/projects/agentic-builder-lab/resources/diagram-prompt.md
+++ b/skills/projects/agentic-builder-lab/resources/diagram-prompt.md
@@ -1,0 +1,145 @@
+# Diagram Prompt — Mermaid Templates
+
+Output goes to `drafts/diagrams/[slug].mmd`. The MDX renderer on frankx.ai supports inline Mermaid via ` ```mermaid ` fences, so the same source ships to the build log and the demo brief.
+
+## Choosing a template
+
+| Build type | Use template |
+|---|---|
+| New tool or harness, want to show layers | Stack diagram (graph TD) |
+| Agent loop or verification flow | Agent flow (sequenceDiagram) |
+| Tool comparison or eval | Comparison matrix (graph LR) |
+
+Pick one. Resist the urge to ship all three for one build. The diagram exists to make one point.
+
+## Rendering
+
+Render with Mermaid CLI:
+
+```bash
+npx -y @mermaid-js/mermaid-cli -i drafts/diagrams/<slug>.mmd -o drafts/diagrams/<slug>.svg -t dark -b transparent
+```
+
+If the `oracle-diagram-generator` skill is available in the current session, prefer it for higher-fidelity output. Otherwise the Mermaid CLI is fine.
+
+## Template 1 — Stack diagram
+
+For a build that wants to show the layers from user input down to deploy. Use when the build introduces a new harness, MCP server, or tool integration.
+
+```mermaid
+graph TD
+  User[Builder] -->|prompt or commit| Tool[Agent Harness]
+  Tool -->|orchestrates| Agents{Agent Pool}
+  Agents -->|reads + writes| Repo[(Repo)]
+  Repo -->|PR opens| Verify[Verification Layer]
+  Verify -->|pass| Deploy[Deploy Target]
+  Verify -->|fail| Tool
+  Deploy -->|URL| Public[Live Endpoint]
+
+  classDef tool fill:#1e293b,stroke:#64748b,color:#f8fafc
+  classDef agent fill:#0c4a6e,stroke:#0ea5e9,color:#f0f9ff
+  classDef repo fill:#1f2937,stroke:#6b7280,color:#f9fafb
+  class Tool,Verify,Deploy tool
+  class Agents agent
+  class Repo repo
+```
+
+Fill-in rules:
+
+- `Agent Harness` — name the specific tool (Antigravity, Claude Code, Aider).
+- `Agent Pool` — number and role of agents.
+- `Verification Layer` — what the gate actually checks.
+- `Deploy Target` — Vercel, Fly, Modal, etc.
+
+## Template 2 — Agent flow
+
+For a build where the story is the loop. Use when the receipt is the sequence of agent handoffs.
+
+```mermaid
+sequenceDiagram
+  participant H as Human
+  participant O as Orchestrator
+  participant A1 as Agent 1
+  participant A2 as Agent 2
+  participant V as Verification
+  participant R as Repo
+
+  H->>O: prompt + scope
+  O->>A1: subtask A
+  O->>A2: subtask B
+  A1-->>O: result + diff
+  A2-->>O: result + diff
+  O->>V: combined diff
+  V->>V: run eval suite
+  alt eval passes
+    V->>R: merge PR
+    R-->>H: shipped
+  else eval fails
+    V-->>O: failure reason
+    O->>A1: revise
+  end
+```
+
+Fill-in rules:
+
+- Rename `Agent 1` and `Agent 2` to the actual agents.
+- The `alt` block stays — it forces the diagram to show both the pass and the fail path.
+- If there are more than two agents, add participants. Do not exceed five — beyond five the diagram becomes unreadable.
+
+## Template 3 — Comparison matrix
+
+For a build that's really a tool eval. Use when the artifact is `Tool A vs Tool B vs Tool C` and the build log is making a recommendation.
+
+```mermaid
+graph LR
+  subgraph Antigravity
+    A1[Parallel agent branches]
+    A2[Multi-pane UI]
+    A3[Built-in verification]
+  end
+
+  subgraph ClaudeCode["Claude Code"]
+    C1[Single-agent loop]
+    C2[Strong tool use]
+    C3[CLI native]
+  end
+
+  subgraph Codex
+    X1[Fast diff review]
+    X2[Style-opinionated]
+    X3[CLI native]
+  end
+
+  Build[Build session] --> Antigravity
+  Build --> ClaudeCode
+  Build --> Codex
+
+  classDef tool fill:#0c4a6e,stroke:#0ea5e9,color:#f0f9ff
+  class A1,A2,A3,C1,C2,C3,X1,X2,X3 tool
+```
+
+Fill-in rules:
+
+- Replace the three subgraphs with the tools actually compared.
+- Three bullets per tool max. If a tool has more than three differentiators, you're not making a clean comparison.
+- The arrows from `Build` to each tool show that the same build session was the eval driver.
+
+## Output rules
+
+- Filename: `drafts/diagrams/<slug>.mmd`.
+- File starts with a one-line comment: `%% <build name> — <template choice>`.
+- No banned terms in any node label or comment.
+- Run the render once to confirm syntax before committing.
+
+## Embedding in the MDX
+
+Paste the Mermaid source into the build log MDX inside a ` ```mermaid ` fence. The site renderer handles the rest. Do not link to an SVG unless the diagram is too large for inline (over 30 nodes).
+
+Example inline embed in the MDX:
+
+````
+```mermaid
+graph TD
+  ...
+```
+````

--- a/skills/projects/agentic-builder-lab/resources/linkedin-template.md
+++ b/skills/projects/agentic-builder-lab/resources/linkedin-template.md
@@ -1,0 +1,175 @@
+# LinkedIn Template — Agentic Builder Lab
+
+Nine post combinations: three hook patterns by three close patterns. Pick one of each.
+
+## Constraints
+
+- Length: 1200-1500 characters.
+- Plain text. No markdown rendering on LinkedIn.
+- Max 3 hashtags, placed at the end. No hashtag spam mid-paragraph.
+- Zero exclamation marks.
+- Zero emojis.
+- Banned terms from `voice-spec.md` apply. Lint before publishing.
+- One link only. Put it on its own line near the close.
+
+## The three hooks
+
+### Hook A — Tool-claim contrarian
+
+Opens with a contrarian one-liner about a tool everyone is hyping. Sets up the build as evidence for the contrarian read.
+
+Pattern:
+
+```
+<Tool> isn't a <common framing>. It's a <truer framing>.
+
+Here's what we shipped this week to prove it.
+
+<2-3 short paragraphs of build receipt: what we built, the stack, the outcome metric.>
+
+<One paragraph on what broke.>
+```
+
+Example opener:
+
+```
+Antigravity isn't a VS Code replacement. It's a harness for running parallel agent branches with verification baked in.
+
+We shipped 3 PRs in one afternoon using it. Here's the architecture.
+```
+
+### Hook B — Build receipt
+
+Opens with the outcome metric in the first line. No setup. The post is the receipt.
+
+Pattern:
+
+```
+Shipped <outcome metric> in <timeframe> using <stack, top 3>.
+
+Here's the build.
+
+<Stack breakdown — one line per tool.>
+
+<What worked — 3 bullets.>
+
+<What broke — 1-2 bullets, honest.>
+```
+
+Example opener:
+
+```
+Shipped 3 PRs in one afternoon using Antigravity, Codex CLI, and Claude Code in a verification loop.
+
+Here's how the loop runs.
+```
+
+### Hook C — Role-shift thesis
+
+Opens with a claim about how the developer role is changing, then uses the build as a worked example.
+
+Pattern:
+
+```
+The <role> role is splitting. <Old version> is one job. <New version> is another.
+
+Here's a build that lives on the new side.
+
+<Short build summary.>
+
+<One concrete thing that's different about how this work happened versus the old way.>
+```
+
+Example opener:
+
+```
+The developer role is splitting. Writing code is one job. Orchestrating agents that write code is another.
+
+This week we built a verification loop where two agents argue about every PR before it merges. The human picks the tiebreaker. That's the new job.
+```
+
+## The three closes
+
+### Close A — Link to the build log
+
+```
+Full write-up with the stack, what worked, and what broke:
+https://frankx.ai/agentic-builder-lab/<slug>
+
+#AgenticAI #DevTools #BuildInPublic
+```
+
+### Close B — CTA to /build
+
+```
+We're packaging this loop as a workshop and a template at /build:
+https://frankx.ai/build
+
+#AgenticAI #AIEngineering #DevTools
+```
+
+### Close C — Question to drive comments
+
+```
+Question for builders shipping with agents: how do you break ties when two agents disagree on the same PR?
+
+Reading every reply.
+
+https://frankx.ai/agentic-builder-lab/<slug>
+
+#AgenticAI #DevTools
+```
+
+## The nine combinations
+
+| ID | Hook | Close | Best for |
+|---|---|---|---|
+| A1 | Contrarian | Build log link | Launching a build log entry |
+| A2 | Contrarian | /build CTA | When the build maps to a workshop or template |
+| A3 | Contrarian | Question | Driving conversation, not clicks |
+| B1 | Receipt | Build log link | Default for shipping-status builds |
+| B2 | Receipt | /build CTA | Receipt that doubles as a product launch |
+| B3 | Receipt | Question | Receipt where the lesson is open |
+| C1 | Role-shift | Build log link | Thought-leadership with proof |
+| C2 | Role-shift | /build CTA | Tying thesis to a paid offer |
+| C3 | Role-shift | Question | Most discussion-friendly combo |
+
+## Full example post (B1)
+
+```
+Shipped 3 PRs in one afternoon using Antigravity, Codex CLI, and Claude Code in a verification loop.
+
+Here's how the loop runs.
+
+Antigravity opens a PR. Codex CLI reviews the diff first, fast, opinionated on style. Claude Code reviews second, slower, better at semantic checks and missing tests. The PR only merges when both agents return a pass verdict.
+
+What worked:
+
+- Two agents disagreeing on the same PR caught 4 bugs single-agent review missed.
+- Pinning a shared lint config dropped false disagreements from 30 percent to 6 percent.
+- Preview deploys per PR let both verifiers hit a live URL before voting.
+
+What broke:
+
+- The loop deadlocked once when both verifiers asked clarifying questions at the same time. We added a 60-second timeout on verifier prompts.
+- We still have no clean way to break ties when verdicts disagree on severity.
+
+Next: a third verifier for security-only checks, and shipping the prompt pair as a GitHub Action.
+
+Full write-up with the stack, what worked, and what broke:
+https://frankx.ai/agentic-builder-lab/antigravity-codex-bridge
+
+#AgenticAI #DevTools #BuildInPublic
+```
+
+Character count check: ~1,420 chars. Within the 1200-1500 window.
+
+## Pre-publish checklist
+
+- [ ] Banned-words lint passes.
+- [ ] No exclamation marks.
+- [ ] Length is 1200-1500 chars.
+- [ ] Exactly one link, on its own line.
+- [ ] Max 3 hashtags, at the end.
+- [ ] What broke section is honest, not flattering.
+- [ ] Outcome metric appears in either the hook or the first paragraph.

--- a/skills/projects/agentic-builder-lab/resources/mdx-template.md
+++ b/skills/projects/agentic-builder-lab/resources/mdx-template.md
@@ -1,0 +1,148 @@
+# MDX Build-Log Template
+
+Write the build log to `content/builds/[slug].mdx`. Match the website's existing MDX frontmatter style (gray-matter). The template below is the canonical shape — fill in every field. Use `null` for missing optional fields, never an empty string.
+
+## Template
+
+````mdx
+---
+title: <build name>
+slug: <kebab-case-slug>
+status: <live|shipping|wip|paused|archived>
+day_number: <integer or null>
+stack: [<tool>, <tool>, ...]
+outcome_metric: <one quantifiable result, or null>
+demo_url: <url or null>
+repo_url: <url or null>
+started_at: <ISO date YYYY-MM-DD>
+last_updated: <ISO date YYYY-MM-DD>
+summary: <one sentence, technical, no banned words>
+---
+
+## What we built
+
+<One paragraph. Lead with what the build does, the primary tool, and the outcome. No setup, no narrative arc. The reader is a builder scanning for whether this is useful to them.>
+
+## The stack and why
+
+<One subheader per tool. 2-4 lines per tool. State the role the tool plays in the build, not its marketing description.>
+
+### <Tool 1>
+
+<Role in this build. What it did that another tool would not have done as well. One line on what surprised us, if anything.>
+
+### <Tool 2>
+
+<Role. Why this tool over the alternative we considered.>
+
+### <Tool N>
+
+<Same shape.>
+
+## What worked
+
+- <Concrete bullet. Include a number where possible.>
+- <Concrete bullet. Name the primitive or pattern.>
+- <Concrete bullet. Tie it back to the outcome metric if relevant.>
+
+## What broke
+
+- <Honest bullet. Name the failure mode by what actually happened.>
+- <Honest bullet. Include the workaround if there was one.>
+- <Honest bullet. If it's still broken, say so.>
+
+## One reusable artifact
+
+We pulled one reusable piece out of this build and added it to the prompt pack:
+
+- **Artifact:** <name>
+- **Where it lives:** `skills/projects/agentic-builder-lab/resources/prompt-pack/<slug>.md`
+- **What it does:** <one line>
+- **How to use it:** <one line>
+
+## Next
+
+<One or two lines. What we ship next for this build, or what we learned that changes the next build.>
+````
+
+## Frontmatter field rules
+
+- `title` — same as `build_name` input. Sentence case. No emojis.
+- `slug` — kebab-case. If not provided, derive from `title`: lowercase, spaces to hyphens, drop non-alphanumeric.
+- `status` — exactly one of: `live`, `shipping`, `wip`, `paused`, `archived`.
+- `day_number` — integer or `null`. Used by the website to render the build-in-public counter.
+- `stack` — YAML array of tool names. Order matters (most central first).
+- `outcome_metric` — short string with a number. Examples: `"3 PRs merged in one afternoon"`, `"latency p95 dropped from 2.1s to 800ms"`, `"deployed in 12 minutes"`. Use `null` if no clean metric exists.
+- `demo_url`, `repo_url` — full URLs starting with `https://`. Use `null` if not public yet.
+- `started_at`, `last_updated` — ISO `YYYY-MM-DD`. Both required.
+- `summary` — one sentence, under 200 chars, no banned words, no exclamation marks. This is what the index page and OG card show.
+
+## Body rules
+
+- The five body sections (`What we built`, `The stack and why`, `What worked`, `What broke`, `One reusable artifact`, `Next`) are required. Plus `Next` makes six. If a section is empty, write a one-line note about why, do not delete the header.
+- The `What broke` section must contain at least one honest item. If nothing broke, the build was too small to log.
+- Code fences allowed. Mermaid diagrams allowed inline using ` ```mermaid ` fences — the website renders these.
+- Do not include images in the MDX directly. Link to assets in the repo or hosted elsewhere.
+
+## Example (fully filled)
+
+````mdx
+---
+title: Antigravity Codex Bridge
+slug: antigravity-codex-bridge
+status: shipping
+day_number: 14
+stack: [Antigravity, Codex CLI, Claude Code, Vercel]
+outcome_metric: 3 PRs merged in one afternoon
+demo_url: https://example.com/demo
+repo_url: https://github.com/frankxai/example
+started_at: 2026-05-20
+last_updated: 2026-05-25
+summary: A two-agent verification loop that runs Codex and Claude in parallel on every PR and only merges when both agree.
+---
+
+## What we built
+
+A two-agent verification loop. Codex CLI and Claude Code both review every PR opened by the Antigravity harness. The PR only merges when both agents return a pass verdict. We shipped 3 PRs in one afternoon.
+
+## The stack and why
+
+### Antigravity
+
+Drives the build loop and opens PRs. Picked over a plain Claude Code session because we needed parallel branches and the multi-pane view to watch verification run.
+
+### Codex CLI
+
+Acts as the first verifier. Fast, opinionated on style, catches lint issues Claude misses.
+
+### Claude Code
+
+Acts as the second verifier. Slower, better at semantic checks and test coverage gaps.
+
+### Vercel
+
+Deploys preview URLs on every PR so verifiers can hit a live endpoint before voting.
+
+## What worked
+
+- Two agents disagreeing on the same PR caught 4 bugs that single-agent verification missed.
+- Pinning a shared lint config dropped false disagreements from 30% to 6%.
+- Preview deploys per PR let verifiers test against a live URL, not a mock.
+
+## What broke
+
+- Codex and Claude argued about formatting for the first three PRs until we pinned the lint config.
+- The harness deadlocked once when both verifiers asked clarifying questions at the same time. Workaround: a 60s timeout on verifier prompts.
+- We still have no good way to break ties when both verifiers pass but disagree on severity.
+
+## One reusable artifact
+
+- **Artifact:** Two-agent verification prompt pair
+- **Where it lives:** `skills/projects/agentic-builder-lab/resources/prompt-pack/antigravity-codex-bridge.md`
+- **What it does:** Runs Codex and Claude on the same diff and returns structured pass/fail verdicts.
+- **How to use it:** Drop into any CI step that has both CLIs installed.
+
+## Next
+
+Add a third verifier for security-only checks. Ship the prompt pair as a GitHub Action.
+````

--- a/skills/projects/agentic-builder-lab/resources/prompt-pack-conventions.md
+++ b/skills/projects/agentic-builder-lab/resources/prompt-pack-conventions.md
@@ -1,0 +1,150 @@
+# Prompt Pack Conventions
+
+Every build produces one reusable artifact that lives in the prompt pack. The pack is the cumulative library of patterns this skill produces over time.
+
+## Location
+
+```
+skills/projects/agentic-builder-lab/resources/prompt-pack/
+```
+
+One file per artifact. Filename matches the build slug: `<slug>.md`.
+
+## Required structure
+
+Every prompt-pack file has four sections in this order:
+
+1. Frontmatter (YAML, gray-matter style).
+2. Prompt body (the actual prompt or template).
+3. Expected output structure.
+4. One or two example invocations.
+
+## Frontmatter schema
+
+```yaml
+---
+title: <human-readable name>
+slug: <kebab-case, matches filename>
+purpose: <one sentence on what this prompt does>
+tool: <primary tool this is designed for — Claude Code, Codex CLI, Antigravity, generic LLM, etc.>
+inputs:
+  - <input name>: <one-line description>
+  - <input name>: <one-line description>
+outputs:
+  - <output name>: <one-line description>
+source_build: <slug of the build that produced this prompt>
+status: <draft|stable|deprecated>
+last_updated: <YYYY-MM-DD>
+---
+```
+
+Field rules:
+
+- `tool` — name the tool the prompt is tuned for. If the prompt is portable, use `generic LLM`.
+- `inputs` and `outputs` — list, do not paragraph. Each item is `name: description`.
+- `source_build` — links the prompt back to the build log it came from. The website cross-renders this link.
+- `status` — `draft` for unverified, `stable` once it's been used in two or more builds, `deprecated` when superseded.
+
+## Prompt body rules
+
+- Wrap the prompt in a code fence so it can be copied cleanly.
+- Use `<placeholder>` syntax for variables, not `{{ jinja }}` or `${js}`. Keep it tool-agnostic.
+- No banned terms (see `voice-spec.md`).
+- If the prompt is multi-turn, label each turn: `## Turn 1 — <role>`, `## Turn 2 — <role>`.
+
+## Expected output structure
+
+Show what a passing output looks like. This is the eval contract. Use a code fence with the expected shape — JSON schema, markdown skeleton, or a sample output trimmed to the structural bones.
+
+If the output is freeform, say so explicitly: `Output is freeform prose. No structural contract.` Do not pretend a structure exists when it doesn't.
+
+## Example invocations
+
+One or two worked examples. Show inputs and the resulting output (trimmed if long). This is what makes the prompt copyable.
+
+Format:
+
+````markdown
+### Example 1 — <short description>
+
+**Inputs:**
+
+- `<input_name>`: <value>
+- `<input_name>`: <value>
+
+**Output (trimmed):**
+
+```
+<sample output>
+```
+
+**Notes:** <one line on edge cases or known failure modes>
+````
+
+## File template
+
+````markdown
+---
+title: <Prompt name>
+slug: <kebab-case>
+purpose: <one sentence>
+tool: <Claude Code | Codex CLI | Antigravity | generic LLM>
+inputs:
+  - <name>: <description>
+outputs:
+  - <name>: <description>
+source_build: <slug>
+status: <draft|stable|deprecated>
+last_updated: <YYYY-MM-DD>
+---
+
+# <Prompt name>
+
+<One paragraph on what this prompt does and when to reach for it.>
+
+## The prompt
+
+```
+<full prompt body, with <placeholder> variables>
+```
+
+## Expected output
+
+```
+<sample structured output, or a note saying output is freeform>
+```
+
+## Examples
+
+### Example 1 — <description>
+
+**Inputs:**
+
+- `<name>`: <value>
+
+**Output (trimmed):**
+
+```
+<output>
+```
+
+**Notes:** <edge cases>
+````
+
+## Naming and uniqueness
+
+- Slugs are unique across the pack. Never overwrite an existing file without asking the user.
+- If a build produces a prompt that's a variant of an existing one, suffix the slug: `agents-md-v2.md`, not a fresh prompt with the same intent.
+- When a prompt graduates from `draft` to `stable`, update the frontmatter, do not rename the file.
+
+## Cross-linking
+
+The MDX build log links to the prompt-pack entry under the `One reusable artifact` section. The prompt-pack file's `source_build` frontmatter field links back. Both directions must resolve.
+
+## What does not belong in the pack
+
+- One-off prompts that won't be reused.
+- Prompts that contain build-specific secrets, tokens, or private URLs.
+- Prompts that depend on a private repo for context — extract the context first.
+
+If the artifact from a build doesn't meet the bar for the pack, say so in the build log's `One reusable artifact` section: `No reusable artifact from this build. The pattern was too specific to the project.` This is fine and on-brand.

--- a/skills/projects/agentic-builder-lab/resources/prompt-pack/example-agents-md.md
+++ b/skills/projects/agentic-builder-lab/resources/prompt-pack/example-agents-md.md
@@ -1,0 +1,168 @@
+---
+title: AGENTS.md scaffold for agentic dev repos
+slug: example-agents-md
+purpose: Generate a project-level AGENTS.md that documents how human contributors and AI agents share a repo, including tool boundaries, branch conventions, and verification gates.
+tool: generic LLM
+inputs:
+  - repo_name: short name for the project
+  - primary_tools: list of agent harnesses or CLIs used in this repo (Claude Code, Antigravity, Codex CLI, etc.)
+  - deploy_target: where the repo deploys to (Vercel, Fly, Modal, none)
+  - verification_strategy: how PRs get verified (single-agent review, two-agent loop, human review only)
+outputs:
+  - agents_md: a complete AGENTS.md file ready to drop at the repo root
+source_build: example-agents-md
+status: stable
+last_updated: 2026-05-25
+---
+
+# AGENTS.md scaffold for agentic dev repos
+
+A starter prompt that produces an `AGENTS.md` file documenting how humans and agents share a repo. Drop the output at the repo root. Agents and contributors read it before opening a PR.
+
+This is the first entry in the prompt pack. It proves the pack works and gives the next builder a real artifact to copy.
+
+## The prompt
+
+```
+You are generating an AGENTS.md file for a repo called <repo_name>.
+
+The repo uses these agent harnesses and CLIs as the primary tools: <primary_tools>.
+The repo deploys to: <deploy_target>.
+The verification strategy is: <verification_strategy>.
+
+Write an AGENTS.md with these sections in order:
+
+1. Purpose — one paragraph on what this repo is and who works on it.
+2. Tools — one subsection per tool in primary_tools. For each, list:
+   - role in this repo
+   - what the tool is allowed to write
+   - what the tool is not allowed to write
+3. Branch and PR conventions — branch naming, commit message format, PR template link.
+4. Verification gate — how a PR gets to merged. Be specific about which agents or humans must approve.
+5. Deploy — one paragraph on the deploy target and who triggers a deploy.
+6. Safety rules — three to five bullets on what no agent should ever do in this repo. Examples: rewrite history on main, commit secrets, push without a PR.
+7. Escalation — who to ping when an agent is stuck or a verification gate disagrees.
+
+Style rules:
+- Technical authority voice. No marketing language.
+- No exclamation marks.
+- Lead with what the rule is, then the reason.
+- Use plain markdown. No HTML.
+- Output the full AGENTS.md content only. No commentary before or after.
+```
+
+## Expected output
+
+```markdown
+# AGENTS.md
+
+## Purpose
+
+<one paragraph>
+
+## Tools
+
+### <Tool 1>
+
+- Role: <role>
+- Allowed to write: <paths or patterns>
+- Not allowed to write: <paths or patterns>
+
+### <Tool 2>
+
+- Role: <role>
+- Allowed to write: <paths or patterns>
+- Not allowed to write: <paths or patterns>
+
+## Branch and PR conventions
+
+- Branch naming: <pattern>
+- Commit format: <pattern>
+- PR template: <path>
+
+## Verification gate
+
+<paragraph on how PRs get merged>
+
+## Deploy
+
+<paragraph>
+
+## Safety rules
+
+- <rule>
+- <rule>
+- <rule>
+
+## Escalation
+
+<one or two lines on who to ping>
+```
+
+## Examples
+
+### Example 1 — Two-agent verification repo
+
+**Inputs:**
+
+- `repo_name`: antigravity-codex-bridge
+- `primary_tools`: Antigravity, Codex CLI, Claude Code
+- `deploy_target`: Vercel
+- `verification_strategy`: two-agent loop, both Codex and Claude must pass
+
+**Output (trimmed):**
+
+```markdown
+# AGENTS.md
+
+## Purpose
+
+This repo hosts a two-agent PR verification loop. Antigravity opens PRs, Codex CLI and Claude Code both review every diff, and only PRs with two passing verdicts get merged.
+
+## Tools
+
+### Antigravity
+
+- Role: opens PRs from agent-driven feature branches.
+- Allowed to write: `feature/*` branches, draft PRs.
+- Not allowed to write: `main`, release tags.
+
+### Codex CLI
+
+- Role: first verifier. Style and lint focus.
+- Allowed to write: PR comments, verdict labels.
+- Not allowed to write: any code in the repo. Reviewer role only.
+
+### Claude Code
+
+- Role: second verifier. Semantic checks and test coverage.
+- Allowed to write: PR comments, verdict labels.
+- Not allowed to write: any code in the repo. Reviewer role only.
+
+## Branch and PR conventions
+
+- Branch naming: `feature/<short-desc>`, `fix/<short-desc>`.
+- Commit format: Conventional Commits.
+- PR template: `.github/pull_request_template.md`.
+
+## Verification gate
+
+A PR merges when both verifier agents return a pass label and CI is green. If verifiers disagree, the human reviewer breaks the tie.
+
+## Deploy
+
+Vercel deploys preview URLs on every PR. Production deploys run on merge to main.
+
+## Safety rules
+
+- No agent rewrites history on main.
+- No agent commits secrets. Pre-commit hook enforces this.
+- No agent merges its own PR. The verifiers and the merger are different identities.
+- No agent pushes without a PR.
+
+## Escalation
+
+Ping the repo owner in the PR thread if both verifiers fail twice on the same diff.
+```
+
+**Notes:** If the repo only uses one verifier, drop the second verifier section and update the verification gate paragraph. The prompt produces a slightly different shape — that's fine.

--- a/skills/projects/agentic-builder-lab/resources/voice-spec.md
+++ b/skills/projects/agentic-builder-lab/resources/voice-spec.md
@@ -1,0 +1,96 @@
+# Voice Spec — Agentic Builder Lab
+
+This file overrides the default studio voice used by `frankx-brand` for every artifact produced by the `agentic-builder-lab` skill. Load this file after `frankx-brand`. These rules win.
+
+## The default
+
+Technical authority. Results-led. A builder talking to other builders who have shipped code this week.
+
+If a sentence could appear in a developer's PR description without raising an eyebrow, it passes. If it sounds like a launch deck or a wellness app, it fails.
+
+## Banned terms (hard fail)
+
+These words do not appear in any output of this skill. Lint at exit by greppling for them.
+
+```
+soul
+awaken
+transformation
+alignment
+journey
+intentional
+sacred
+energy
+vibration
+frequency
+studio        (when used as a metaphor — fine for "recording studio")
+elevate       (when used as a metaphor — fine for "elevate floor 3")
+unlock        (when used as a metaphor — fine for "unlock the door")
+```
+
+Edge cases:
+
+- `frequency` is fine in a literal RF or sample-rate context. Banned as a metaphor for energy or vibe.
+- `journey` is fine in `customer journey` only if the surrounding paragraph is technical. Default: rewrite.
+- `intentional` is banned. Use `deliberate` or just describe the choice.
+
+## Encouraged terms
+
+These read native to the audience.
+
+```
+architect      agent          verification   orchestration
+stack          primitive      harness        scaffold
+ship           repo           PR             eval
+diff           rollback       sandbox        prompt
+context        token          latency        cost-per-call
+```
+
+## Structural rules
+
+1. **Lead with what was built, what tool, what outcome.** First sentence of any artifact answers all three.
+2. **No exclamation marks.** Anywhere. Periods do the work.
+3. **No hype adjectives.** Cut: amazing, incredible, game-changing, mind-blowing, revolutionary, magical.
+4. **One claim per sentence.** If a sentence has two claims, split it.
+5. **Numbers beat adjectives.** "Latency dropped 40%" not "huge latency win".
+6. **Show the receipt or cut the claim.** No unbacked superlatives.
+7. **Failures named, not hidden.** Every build log has a "what broke" section. Be specific.
+8. **No second person hype.** Don't tell the reader they'll be transformed. Tell them what the build does.
+9. **Verbs over nouns.** "We shipped X" beats "the shipment of X was completed".
+10. **Three-word rule.** If a sentence opens with three buzzwords back to back, rewrite it.
+
+## Tone calibration
+
+| Calibration | Example pass | Example fail |
+|---|---|---|
+| First line of a build log | `Built a two-agent verification loop on Antigravity. 3 PRs merged in one afternoon.` | `Embarked on a transformative journey into the soul of agentic coding.` |
+| Closing line of a LinkedIn post | `Repo and write-up linked below.` | `Unlock your potential — start your journey today.` |
+| Diagram caption | `Human prompt → orchestrator → 2 verifier agents → merge.` | `The sacred flow of intentional creation.` |
+| What broke section | `The verifier agents kept disagreeing on style. Solution: pinned a shared lint config.` | `We learned to honor the rhythm of the build.` |
+
+## Humility default
+
+Frank's brand is humility plus excellence. Showing what broke is on-brand. Hiding it is off-brand.
+
+- Lead a build log with the outcome, but spend a section on the failures.
+- If a tool didn't work for the use case, say so by name. No vague "some tools struggled".
+- If a build is `wip` or `paused`, the artifact says that in the frontmatter and the body. No fake "shipping soon".
+
+## Person and tense
+
+- First person plural (`we`) when describing the build.
+- First person singular (`I`) when the builder is alone and the artifact is signed.
+- Past tense for what happened. Present tense for what the artifact does. Future tense only with a date attached.
+
+## What gets cut
+
+A pass over any draft removes:
+
+- Sentences that summarize the previous sentence.
+- Adverbs ending in `-ly` that don't change meaning (`really`, `actually`, `basically`).
+- Phrases like "in today's world", "at the end of the day", "needless to say".
+- Em-dash drama. One em-dash per paragraph max.
+
+## When in doubt
+
+If a sentence could be deleted without losing information, delete it. The audience is busy.

--- a/skills/registry.json
+++ b/skills/registry.json
@@ -309,6 +309,25 @@
         "commands": ["/agentic-orchestration"]
       },
       "exports": ["orchestration_patterns", "handoff_protocols", "state_machines"]
+    },
+
+    "agentic-builder-lab": {
+      "version": "0.1.0",
+      "category": "projects",
+      "description": "Convert a single build session into MDX build-log entry, LinkedIn draft, demo brief, Mermaid diagram, and a reusable prompt for the /agentic-builder-lab and /build pages on frankx.ai.",
+      "author": "FrankX",
+      "license": "MIT",
+      "downloads": 0,
+      "rating": 0,
+      "dependencies": ["frankx-brand"],
+      "mcp": ["filesystem-mcp"],
+      "triggers": {
+        "keywords": ["log a build", "build session log", "agentic-builder-lab", "build log"],
+        "files": ["**/content/builds/**", "**/drafts/linkedin/**", "**/drafts/demos/**", "**/drafts/diagrams/**"],
+        "commands": ["/build-log", "/agentic-builder-lab"]
+      },
+      "exports": ["mdx_build_log", "linkedin_draft", "demo_brief", "mermaid_diagram", "prompt_pack_entry"],
+      "voice_override": "resources/voice-spec.md"
     }
   },
 
@@ -337,6 +356,9 @@
       "7-pillars",
       "life-symphony",
       "golden-path"
+    ],
+    "projects": [
+      "agentic-builder-lab"
     ]
   },
 


### PR DESCRIPTION
## Summary

Adds a new ACOS skill at `skills/projects/agentic-builder-lab/` that converts a single build session into the full content flywheel: an MDX build-log entry, a LinkedIn draft, a 60–90s demo brief, a Mermaid architecture diagram, and one reusable prompt added to the pack.

Companion to the website PR at `frankxai/frankx.ai-vercel-website#claude/agentic-builder-lab-plan-ruxnO`, which renders the MDX output at `/agentic-builder-lab`.

## What ships

- `SKILL.md` — main spec with YAML frontmatter (triggers, inputs, outputs, voice override), 5-step flow, example invocation
- `resources/voice-spec.md` — the voice override: technical-authority register with a banned-words list (soul, transformation, studio metaphor, etc.) and an encouraged-words list. Loaded **after** `frankx-brand` so it overrides the studio register for this scope only.
- `resources/mdx-template.md` — gray-matter MDX template matching the website's `content/builds/[slug].mdx` schema
- `resources/linkedin-template.md` — 9 combinations (3 hooks × 3 closes), 1200–1500 char constraint, pre-publish checklist
- `resources/demo-brief-template.md` — 60–90s structure (Hook / Setup / Demo / What broke+worked / CTA), shot list, voiceover script
- `resources/diagram-prompt.md` — 3 Mermaid templates (Stack TD, Agent flow sequenceDiagram, Comparison LR)
- `resources/prompt-pack-conventions.md` — schema and conventions for new pack entries
- `resources/prompt-pack/example-agents-md.md` — starter pack entry: an AGENTS.md generator prompt

Registry updates: `skills/registry.json` adds the entry with `dependencies: [frankx-brand]` and `commands: [/build-log, /agentic-builder-lab]`. `CLAUDE.md` adds `/build-log` to the Creation commands table.

## Voice lint

All output templates pass the banned-word lint cleanly. Remaining banned-term hits in `SKILL.md` and `voice-spec.md` are confined to the ban-list definitions themselves, the calibration table's "fail" column, and edge-case explanations. Zero exclamation marks anywhere in the skill.

## Test plan

- [ ] `/build-log` slash command invokes the skill
- [ ] Skill auto-triggers on "log a build" keyword
- [ ] Voice-spec.md loads after frankx-brand (studio voice suppressed in output)
- [ ] All 5 output artifacts generated from a sample input
- [ ] MDX frontmatter validates against the website's `lib/builds.ts` loader
- [ ] Banned-word lint passes on every artifact before exit

## Related

- Website PR: https://github.com/frankxai/frankx.ai-vercel-website/pull/new/claude/agentic-builder-lab-plan-ruxnO
- Plan file: `/root/.claude/plans/plan-to-build-frankx-ai-agentic-builder-replicated-sutherland.md`

https://claude.ai/code/session_012dr4zpf6FsJygEDzt5a83N

---
_Generated by [Claude Code](https://claude.ai/code/session_012dr4zpf6FsJygEDzt5a83N)_