### PR TITLE
fix(skills): lint scope + section count in agentic-builder-lab

### DIFF
--- a/skills/projects/agentic-builder-lab/SKILL.md
+++ b/skills/projects/agentic-builder-lab/SKILL.md
@@ -100,6 +100,9 @@ The MDX file is the canonical artifact. The other four reference it.
 After all files are written, grep each one for banned terms. If any banned term appears, rewrite that artifact before exit. Suggested check:
 
 ```bash
+# studio, elevate, unlock are banned as metaphors only. Literal usage
+# ("recording studio", "elevate floor 3", "unlock the door") is fine —
+# review each hit against resources/voice-spec.md before rewriting.
 BANNED="soul|awaken|transformation|alignment|journey|intentional|sacred|energy|vibration|frequency|studio|elevate|unlock"
 grep -InE "\\b($BANNED)\\b" \
   content/builds/[slug].mdx \

--- a/skills/projects/agentic-builder-lab/SKILL.md
+++ b/skills/projects/agentic-builder-lab/SKILL.md
@@ -100,8 +100,13 @@ The MDX file is the canonical artifact. The other four reference it.
 After all files are written, grep each one for banned terms. If any banned term appears, rewrite that artifact before exit. Suggested check:
 
 ```bash
-BANNED="soul|awaken|transformation|alignment|journey|intentional|sacred|energy|vibration|frequency"
-grep -InE "\\b($BANNED)\\b" content/builds/[slug].mdx drafts/linkedin/[slug].md drafts/demos/[slug]-brief.md
+BANNED="soul|awaken|transformation|alignment|journey|intentional|sacred|energy|vibration|frequency|studio|elevate|unlock"
+grep -InE "\\b($BANNED)\\b" \
+  content/builds/[slug].mdx \
+  drafts/linkedin/[slug].md \
+  drafts/demos/[slug]-brief.md \
+  drafts/diagrams/[slug].mmd \
+  skills/projects/agentic-builder-lab/resources/prompt-pack/[slug].md
 ```
 
 Lint must pass on a clean exit.

--- a/skills/projects/agentic-builder-lab/resources/mdx-template.md
+++ b/skills/projects/agentic-builder-lab/resources/mdx-template.md
@@ -79,7 +79,7 @@ We pulled one reusable piece out of this build and added it to the prompt pack:
 
 ## Body rules
 
-- The five body sections (`What we built`, `The stack and why`, `What worked`, `What broke`, `One reusable artifact`, `Next`) are required. Plus `Next` makes six. If a section is empty, write a one-line note about why, do not delete the header.
+- The six body sections (`What we built`, `The stack and why`, `What worked`, `What broke`, `One reusable artifact`, `Next`) are required. If a section is empty, write a one-line note about why, do not delete the header.
 - The `What broke` section must contain at least one honest item. If nothing broke, the build was too small to log.
 - Code fences allowed. Mermaid diagrams allowed inline using ` ```mermaid ` fences — the website renders these.
 - Do not include images in the MDX directly. Link to assets in the repo or hosted elsewhere.


### PR DESCRIPTION
## Summary

Two quality fixes in `agentic-builder-lab` flagged by CodeRabbit during the review of the website mirror PR (`frankxai/frankx.ai-vercel-website#104`). Pushing them upstream so the next mirror port doesn't re-introduce them.

## Findings

### 1. SKILL.md — lint scope drift

The banned-words lint command claimed to validate every artifact the skill produces, but actually:
- Scanned **3 of the 5** output paths (missing `drafts/diagrams/[slug].mmd` and the prompt-pack entry).
- Used a **subset of the banned-words list** declared in `voice-spec.md` — missing `studio`, `elevate`, `unlock`.

Result: false "clean exit" passes whenever a banned term landed in the diagram caption or the prompt-pack body.

Fix: expand BANNED to all 13 tokens; scan all 5 artifact paths.

### 2. mdx-template.md — section count contradiction

Body rules said *"The **five** body sections (..., Next) are required. Plus `Next` makes six."* The six headers are required; the count `five` was a leftover from before `Next` was added. Strict template-following runs hit the contradiction.

Fix: rename to `six body sections`, drop the hedge.

## Companion PR

The same two fixes (plus 6 more — README counts, MD022 spacing, and 4 script improvements from Gemini) landed on the website mirror in `frankxai/frankx.ai-vercel-website#105`. This ACOS PR is the upstream half so the canonical skill matches the corrected mirror.

## Test plan

- [ ] CI green (same green pipeline as `#11`: install → build:all → lint → typecheck)
- [ ] Banned-word check on existing prompt-pack entries still passes
- [ ] No semantic change to the 5-artifact flywheel — only lint and doc fixes

https://claude.ai/code/session_012dr4zpf6FsJygEDzt5a83N

---
_Generated by [Claude Code](https://claude.ai/code/session_012dr4zpf6FsJygEDzt5a83N)_