### PR TITLE
fix(docs): branch audit SAFE_DELETE count (6 → 8)

### DIFF
--- a/BRANCH_AUDIT.md
+++ b/BRANCH_AUDIT.md
@@ -10,7 +10,7 @@ If a branch is marked `SAFE_DELETE`, every meaningful change it contains is alre
 
 | Status | Count |
 |---|---|
-| `SAFE_DELETE` (work in main) | 6 |
+| `SAFE_DELETE` (work in main) | 8 |
 | `KEEP` (active PR) | 2 |
 | `KEEP_BACKUP` (staging snapshot) | 1 |
 


### PR DESCRIPTION
Gemini code review caught: summary table said `SAFE_DELETE` count = 6, but the section below lists 8 branches and the cleanup script deletes all 8. Updating to 8 so the table is consistent with reality.

One-line doc fix. No code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_012dr4zpf6FsJygEDzt5a83N)_