### PR TITLE
feat(ops): /ops skill — weekly operations loop

### DIFF
--- a/.claude/commands/ops.md
+++ b/.claude/commands/ops.md
@@ -1,0 +1,37 @@
+# /ops — Weekly Operations Loop
+
+**The execution layer of the FrankX Operations System.** One command surfaces
+everything that needs attention across the business and drives each item one
+step forward.
+
+Loads the `ops` skill (`skills/ops/SKILL.md`).
+
+## Usage
+
+```bash
+/ops              # full loop: inbox · pipeline · PRs · content
+/ops inbox        # just triage new inquiries + draft replies
+/ops pipeline     # just advance CRM stages
+/ops prs          # just sweep open PRs across both repos
+```
+
+## What it does
+
+1. **Inbox** — pull `New` inquiries from the Notion Inquiries CRM (or
+   `/admin/intake`), classify urgency, draft replies in Frank's voice, advance
+   `New → Triaged`.
+2. **Pipeline** — advance `Triaged / Call booked / Proposal` rows; flag anything
+   stuck > 14 days.
+3. **PRs** — list open PRs in `frankxai/frankx.ai-vercel-website` and
+   `frankxai/agentic-creator-os`; build a merge queue + a fix queue.
+4. **Content** — what shipped, what's queued, one recommended next piece (feeds
+   the `/build-log` flywheel).
+
+## Guardrails
+
+- Never auto-send a reply or close a deal without confirmation. Draft and propose.
+- Voice: technical authority. Lead with the answer, link the artifact.
+- If the pipeline is empty or PRs are clean, say so. No invented busywork.
+
+See `docs/ops/OPERATIONS_SYSTEM.md` (website repo) for the full architecture and
+the capture/acknowledge/track layers this loop sits on top of.

--- a/.claude/commands/ops.md
+++ b/.claude/commands/ops.md
@@ -1,3 +1,8 @@
+---
+name: ops
+description: Weekly operations loop — triage the inquiry inbox, advance the CRM pipeline, sweep open PRs across repos, and surface the content plan. Loads the ops skill.
+---
+
 # /ops — Weekly Operations Loop
 
 **The execution layer of the FrankX Operations System.** One command surfaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ See install.sh:install_grok , adapters/grok/ and the new grok-harness skill for 
 | `/inventory-status` | Content inventory dashboard |
 | `/mcp-status` | MCP server health |
 | `/publish` | Content publishing with quality gates |
+| `/ops` | Weekly operations loop — triage inquiry inbox, advance CRM pipeline, sweep PRs, surface content plan (ops skill) |
 
 ### Quality (3)
 | Command | Description |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ See install.sh:install_grok , adapters/grok/ and the new grok-harness skill for 
 | `/ux-design` | UI/UX design workflows |
 | `/automation-dev` | MCP servers & automation |
 
-### System (5)
+### System (6)
 | Command | Description |
 |---------|-------------|
 | `/acos` | Smart router — single entry point |

--- a/skills/ops/SKILL.md
+++ b/skills/ops/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: Ops Cadence
+description: Run the weekly FrankX operations loop — triage the inquiry inbox, advance the CRM pipeline, sweep open PRs across repos, and surface the content plan. Use for "/ops", "run the ops loop", "weekly ops", "triage inquiries", "what needs my attention", or any business-operations check-in.
+version: 0.1.0
+triggers:
+  - "/ops"
+  - "run the ops loop"
+  - "weekly ops"
+  - "triage inquiries"
+  - "what needs my attention"
+  - "ops check-in"
+inputs:
+  required: []
+  optional: [mode, since]
+outputs:
+  - A prioritized ops readout (inbox · pipeline · PRs · content)
+  - Optional: drafted replies, advanced Notion stages, PR actions
+dependencies: [frankx-brand]
+mcp: [notion, github, slack]
+---
+
+# Ops Cadence
+
+The execution layer of the FrankX Operations System. One command surfaces
+everything that needs Frank's attention across the business and drives each
+item one step forward. Pairs with the capture/acknowledge/track layers built
+into frankx.ai (`/api/intake` → Notion "Inquiries" CRM). See
+`docs/ops/OPERATIONS_SYSTEM.md` in the website repo for the full architecture.
+
+## When to run
+
+- **Weekly** (Monday) — the full loop, as a planning ritual.
+- **On demand** — "what needs my attention?" before a focus block.
+- **After a launch** — when inbound spikes and the pipeline needs triage.
+
+## The loop
+
+Four passes, each ending in a concrete action — not just a report.
+
+### 1. Inbox — triage new inquiries
+
+Source: Notion **Inquiries (CRM)** database (or `/admin/intake` if Notion isn't
+wired yet). Pull every row at stage `New`.
+
+For each:
+- Classify urgency (commercial intent + named company + specific ask = hot).
+- Draft a reply in Frank's voice (technical-authority register — see
+  `VOICE_ROUTER.md`). Lead with the answer, propose the next step (call / scope / no-fit).
+- Advance the Notion `Stage`: `New → Triaged`.
+
+Output: a ranked list — hot leads first, each with a ready-to-send draft.
+
+### 2. Pipeline — advance the CRM
+
+Pull rows at `Triaged`, `Call booked`, `Proposal`.
+
+For each, name the single next action and who owns it:
+- `Triaged` with no reply sent → send the draft.
+- `Call booked` with date passed → log outcome, move to `Proposal` or `Lost`.
+- `Proposal` aging > 7 days → nudge or mark `Lost`.
+
+Flag anything stuck > 14 days. Stale pipeline is the silent killer.
+
+### 3. PRs — sweep open work
+
+Across `frankxai/frankx.ai-vercel-website` and `frankxai/agentic-creator-os`:
+- List open PRs with CI status + review state.
+- Green + reviewed → flag for merge.
+- Red CI → diagnose (one line) + propose the fix.
+- Stale draft (> 7 days, no activity) → decide: finish, or close and capture the idea in `BRANCH_AUDIT.md`.
+
+Output: a merge queue and a fix queue.
+
+### 4. Content — surface the plan
+
+- What shipped since last loop (blog, builds, social)?
+- What's queued / half-built (draft PRs, `content/builds/*` at `status: wip`)?
+- One recommended next piece, tied to a real build (feed the `/build-log` flywheel).
+
+## Modes
+
+| Mode | Scope |
+|---|---|
+| `full` (default) | All four passes. |
+| `inbox` | Just triage new inquiries + draft replies. |
+| `pipeline` | Just advance CRM stages. |
+| `prs` | Just the PR sweep. |
+
+## Output shape
+
+```
+## Ops Readout — <date>
+
+### 🔥 Hot (act today)
+- <Name, Company> · <intent> — <one-line ask> → [draft ready]
+
+### 📥 Inbox (N new)
+...
+
+### 📊 Pipeline (N active)
+- Stuck > 14d: ...
+- Next actions: ...
+
+### 🔀 PRs
+- Merge queue: ...
+- Fix queue: ...
+
+### ✍️ Content
+- Shipped: ... | Queued: ... | Recommend next: ...
+```
+
+## Guardrails
+
+- **Never auto-send** a reply or advance a `Won`/`Lost` stage without Frank's
+  confirmation. Draft and propose; Frank approves.
+- **Voice:** technical authority. Lead with the answer, link the artifact, let
+  the work speak. No hype, no guru language.
+- **Honesty:** if the pipeline is empty or PRs are all clean, say so plainly.
+  An ops loop that invents busywork is worse than none.

--- a/skills/ops/SKILL.md
+++ b/skills/ops/SKILL.md
@@ -16,7 +16,7 @@ outputs:
   - A prioritized ops readout (inbox · pipeline · PRs · content)
   - Optional: drafted replies, advanced Notion stages, PR actions
 dependencies: [frankx-brand]
-mcp: [notion, github, slack]
+mcp: [notion-mcp, github-mcp, slack-mcp]
 ---
 
 # Ops Cadence
@@ -45,7 +45,7 @@ wired yet). Pull every row at stage `New`.
 For each:
 - Classify urgency (commercial intent + named company + specific ask = hot).
 - Draft a reply in Frank's voice (technical-authority register — see
-  `VOICE_ROUTER.md`). Lead with the answer, propose the next step (call / scope / no-fit).
+  the `frankx-brand` skill). Lead with the answer, propose the next step (call / scope / no-fit).
 - Advance the Notion `Stage`: `New → Triaged`.
 
 Output: a ranked list — hot leads first, each with a ready-to-send draft.

--- a/skills/registry.json
+++ b/skills/registry.json
@@ -346,6 +346,24 @@
       },
       "exports": ["mdx_build_log", "linkedin_draft", "demo_brief", "mermaid_diagram", "prompt_pack_entry"],
       "voice_override": "resources/voice-spec.md"
+    },
+
+    "ops": {
+      "version": "0.1.0",
+      "category": "business",
+      "description": "Run the weekly FrankX operations loop — triage the inquiry inbox, advance the CRM pipeline, sweep open PRs across repos, and surface the content plan. The execution layer of the FrankX Operations System (frankx.ai /api/intake → Notion Inquiries CRM).",
+      "author": "FrankX",
+      "license": "MIT",
+      "downloads": 0,
+      "rating": 0,
+      "dependencies": ["frankx-brand"],
+      "mcp": ["notion", "github", "slack"],
+      "triggers": {
+        "keywords": ["ops loop", "weekly ops", "triage inquiries", "what needs my attention", "ops check-in", "advance pipeline"],
+        "files": ["**/docs/ops/**", "**/admin/intake/**"],
+        "commands": ["/ops"]
+      },
+      "exports": ["ops_readout", "inbox_triage", "pipeline_advance", "pr_sweep"]
     }
   },
 
@@ -369,7 +387,8 @@
       "publishing-factory"
     ],
     "business": [
-      "oci-services"
+      "oci-services",
+      "ops"
     ],
     "soulbook": [
       "7-pillars",

--- a/skills/registry.json
+++ b/skills/registry.json
@@ -357,7 +357,7 @@
       "downloads": 0,
       "rating": 0,
       "dependencies": ["frankx-brand"],
-      "mcp": ["notion", "github", "slack"],
+      "mcp": ["notion-mcp", "github-mcp", "slack-mcp"],
       "triggers": {
         "keywords": ["ops loop", "weekly ops", "triage inquiries", "what needs my attention", "ops check-in", "advance pipeline"],
         "files": ["**/docs/ops/**", "**/admin/intake/**"],


### PR DESCRIPTION
## `/ops` — the execution layer of the FrankX Operations System

The layer-4 loop that works the pipeline the website builds (frankxai/frankx.ai-vercel-website#201). One command surfaces everything needing attention across the business and drives each item one step forward.

```bash
/ops              # full loop: inbox · pipeline · PRs · content
/ops inbox        # just triage new inquiries + draft replies
/ops pipeline     # just advance CRM stages
/ops prs          # just sweep open PRs across both repos
```

### The four passes

1. **Inbox** — pull `New` inquiries from the Notion Inquiries CRM (or `/admin/intake`), classify urgency, draft replies in Frank's voice, advance `New → Triaged`.
2. **Pipeline** — advance `Triaged / Call booked / Proposal`; flag anything stuck > 14 days.
3. **PRs** — sweep both repos; build a merge queue + a fix queue.
4. **Content** — what shipped / queued + one recommended next piece (feeds `/build-log`).

### Guardrails

- Never auto-send a reply or close a deal without confirmation. Draft and propose.
- Voice: technical authority. Lead with the answer, link the artifact.
- If the pipeline is empty or PRs are clean, say so. No invented busywork.

### Files

- `skills/ops/SKILL.md` — the cadence skill
- `.claude/commands/ops.md` — slash-command wrapper
- `skills/registry.json` — registered under the `business` category (JSON validated)
- `CLAUDE.md` — added `/ops` to the System commands table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012dr4zpf6FsJygEDzt5a83N)_