### PR TITLE
feat: add Natural-Language Agent Harness (NLAH) contract system

### DIFF
--- a/.acos/.gitignore
+++ b/.acos/.gitignore
@@ -1,0 +1,3 @@
+# NLAH execution artifacts are project-local and ephemeral.
+# Only the .gitignore itself is committed.
+artifacts/

--- a/.claude/RUNTIME_CHARTER.md
+++ b/.claude/RUNTIME_CHARTER.md
@@ -1,0 +1,167 @@
+# ACOS Runtime Charter v1.0
+
+This charter defines how the ACOS runtime interprets and enforces Natural-Language Agent Harness (NLAH) contracts. It is loaded at session start and governs all contracted skill execution.
+
+This document is itself an NLAH — a natural-language specification interpreted by the in-loop LLM.
+
+---
+
+## 1. Contract Interpretation
+
+When a skill with a `contract:` block in its SKILL.md frontmatter is activated:
+
+1. **Parse the contract** from YAML frontmatter
+2. **Initialize tracking** — set tool-call counter to 0, file-edit counter to 0, child-agent counter to 0
+3. **Create artifact directory** at the resolved `artifacts.state-dir` path
+4. **Write contract snapshot** to `contract-snapshot.json` in the artifact directory
+5. **Begin execution** — the skill's markdown body is the harness logic
+
+### Variable Resolution
+
+Template variables in contract fields are resolved at activation:
+- `${skill-name}` → the `name` field from frontmatter
+- `${session-id}` → a unique identifier for this execution (timestamp-based)
+
+## 2. Budget Enforcement
+
+Budget enforcement operates through awareness, not hard blocks. The in-loop LLM reads budget state and adjusts behavior accordingly.
+
+### Budget Tracking
+
+After each tool call, update counters:
+- `tool_calls` += 1 for every tool invocation
+- `file_edits` += 1 for every Write or Edit call
+- `child_agents` += 1 for every Agent or Task call
+
+### Budget Signals
+
+| Usage Level | Signal | Expected Behavior |
+|---|---|---|
+| 0-70% of any limit | None | Normal execution |
+| 70-90% of any limit | `[BUDGET WARNING]` | Prioritize remaining work, skip nice-to-haves |
+| 90-100% of any limit | `[BUDGET URGENT]` | Wrap up immediately, write partial artifacts |
+| >100% of any limit | `[BUDGET EXCEEDED]` | Finalize artifact manifest, stop execution |
+
+### Context Budget
+
+When `budget.context-budget` is set, monitor context window usage against the specified fraction. At 70% of the context budget, consider spawning child agents for remaining work rather than consuming more context.
+
+### Timeout
+
+When `budget.timeout-minutes` is set, track wall-clock time from activation. At 80% of timeout, emit `[TIMEOUT WARNING]`. At 100%, finalize and stop.
+
+## 3. Required Outputs
+
+### Verification Methods
+
+**existence** (default): Each required output's file path or glob pattern is checked. The output must exist and be non-empty (>0 bytes).
+
+**content-check**: The LLM reads each output and verifies it matches the `description` field. Score 0.0-1.0 based on completeness and relevance.
+
+**script**: Run the specified verification script. Exit code 0 = pass, non-zero = fail.
+
+**llm-judge**: The LLM scores each output for quality against the description. Must meet `verification.threshold`.
+
+### Optional Outputs
+
+Outputs marked `optional: true` are tracked but don't block completion. Missing optional outputs are logged in the manifest with `"exists": false`.
+
+### Output Timing
+
+Required outputs are verified at two points:
+1. **On-demand**: When the LLM believes the harness is complete
+2. **On-stop**: When the session ends or budget is exhausted
+
+## 4. Permission Composition
+
+Skill permissions compose with `agent-iam.json` profiles using intersection semantics:
+
+1. Start with the IAM profile's permissions (tool access, directory scoping)
+2. **Add** paths from `permissions.additional-paths`
+3. **Remove** paths matching `permissions.denied-paths`
+4. If `can-spawn-agents` is false, deny Agent/Task tool access
+5. If `can-modify-harness` is false, deny Write/Edit to any `SKILL.md` file
+
+The narrower permission always wins. A skill cannot grant itself more access than its IAM profile allows.
+
+## 5. Child Agent Lifecycle
+
+### Spawning
+
+- Check `budget.max-child-agents` before spawning
+- Each child inherits the parent's permissions (can only narrow, never widen)
+- Children receive a fraction of the parent's remaining budget: `remaining_budget / (max_children - active_children)`
+
+### Inheritance
+
+Children inherit:
+- Permission scope (intersection with parent)
+- Artifact directory (children write to `{parent-artifact-dir}/children/{child-id}/`)
+- Budget fraction (decremented from parent's remaining budget)
+
+Children do NOT inherit:
+- Parent's tool-call counter (children have their own)
+- Parent's completion conditions (children have task-specific goals)
+
+### Completion
+
+When a child completes:
+1. Child writes its results as artifacts in its subdirectory
+2. Parent reads child artifacts via the artifact manifest
+3. Child's budget usage is added to parent's totals
+
+### Failure
+
+- Child failure does NOT terminate the parent
+- Parent may retry the child (if budget allows) or proceed without the child's output
+- Failed child runs are logged in the parent's execution log
+
+## 6. Artifact Lifecycle
+
+### Creation
+
+On skill activation with a contract:
+1. Create `{state-dir}` directory
+2. Write `contract-snapshot.json` with the active contract
+3. Create empty `execution-log.jsonl`
+4. Create `outputs/` subdirectory
+
+### During Execution
+
+After each significant action, append to `execution-log.jsonl`:
+```json
+{"timestamp": "...", "action": "tool_call", "tool": "Read", "target": "src/index.ts", "budget_remaining": {"tool_calls": 46}}
+```
+
+### Sealing
+
+On completion (or budget exhaustion):
+1. Verify required outputs
+2. Compute verification scores
+3. Write `artifact-manifest.json` with final state
+4. Write verification results to `verification/`
+
+### Retention
+
+Artifacts older than `artifacts.retention` may be cleaned up on SessionStart. The `_index.json` at `.acos/artifacts/` tracks all runs across skills.
+
+## 7. Harness vs. Runtime Boundary
+
+The charter defines runtime behavior. The skill defines task behavior.
+
+| Belongs in SKILL.md (Harness) | Belongs in Charter (Runtime) |
+|---|---|
+| What to do (workflow steps) | How contracts are enforced |
+| What outputs to produce | How outputs are verified |
+| What budget limits to set | How budget signals are emitted |
+| What permissions to request | How permissions compose |
+| What agents to spawn | How child lifecycle is managed |
+
+This boundary enables portable harnesses: the same SKILL.md can execute under different runtimes (Claude Code, Cursor, generic CLI) with different charter implementations.
+
+## 8. Backward Compatibility
+
+- Skills without a `contract:` block are executed exactly as before — no contract parsing, no budget tracking, no artifact management
+- The charter is advisory for the LLM, not programmatically enforcing — Claude reads it and adjusts behavior
+- Existing hooks (`circuit-breaker.sh`, `context-budget-tracker.ts`) continue to operate independently as hard backstops
+- New NLAH hooks (`contract-enforcer.js`, `artifact-manager.js`) are additive to the hook pipeline

--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -66,6 +66,22 @@
         "type": "command",
         "matcher": "Task|Read|Write|Edit|Bash",
         "command": "cd .claude/hooks && TOOL_NAME=$TOOL_NAME npx tsx context-budget-tracker.ts 2>/dev/null || echo 'Context checkpoint: Monitor drift.'"
+      },
+      {
+        "name": "nlah-contract-enforcer",
+        "description": "NLAH budget enforcement — tracks tool/edit/agent usage against active skill contracts",
+        "type": "command",
+        "matcher": "Write|Edit|Agent|Task|Bash|Read",
+        "command": "node .claude/hooks/contract-enforcer.js 2>/dev/null || true"
+      }
+    ],
+
+    "Stop": [
+      {
+        "name": "nlah-artifact-manager",
+        "description": "NLAH artifact sealing — verifies required outputs and writes manifest when a contracted skill session ends",
+        "type": "command",
+        "command": "node .claude/hooks/artifact-manager.js 2>/dev/null || true"
       }
     ],
 

--- a/.claude/hooks/artifact-manager.js
+++ b/.claude/hooks/artifact-manager.js
@@ -59,7 +59,7 @@ function globMatch(pattern, cwd) {
 
 function matchSegment(pattern, name) {
   if (pattern === '*') return true;
-  const re = new RegExp('^' + pattern.replace(/\./g, '\\.').replace(/\*/g, '.*').replace(/\?/g, '.') + '$');
+  const re = new RegExp('^' + pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.') + '$');
   return re.test(name);
 }
 

--- a/.claude/hooks/artifact-manager.js
+++ b/.claude/hooks/artifact-manager.js
@@ -2,15 +2,66 @@
 
 // NLAH Artifact Manager — Stop hook
 // Seals artifact manifests when a contracted skill session ends.
-// Reads active contract from .acos/artifacts/_active-contract.json,
-// verifies required outputs, writes the final manifest, and clears active state.
+// Reads active contract from .acos/artifacts/_active-contract-{sid}.json,
+// verifies required outputs (with glob support), writes the final manifest,
+// and clears active state.
 
 const fs = require('fs');
 const path = require('path');
 
 const ACOS_DIR = path.join(process.cwd(), '.acos', 'artifacts');
-const ACTIVE_FILE = path.join(ACOS_DIR, '_active-contract.json');
-const BUDGET_FILE = path.join(ACOS_DIR, '_budget-state.json');
+const SESSION_ID = process.env.ACOS_SESSION_ID || process.env.CLAUDE_SESSION_ID || 'default';
+const ACTIVE_FILE = path.join(ACOS_DIR, `_active-contract-${SESSION_ID}.json`);
+const BUDGET_FILE = path.join(ACOS_DIR, `_budget-state-${SESSION_ID}.json`);
+
+function globMatch(pattern, cwd) {
+  if (!pattern.includes('*') && !pattern.includes('?')) {
+    const full = path.join(cwd, pattern);
+    if (fs.existsSync(full)) {
+      const stat = fs.statSync(full);
+      return [{ path: pattern, size: stat.size }];
+    }
+    return [];
+  }
+
+  const parts = pattern.split('/');
+  let dirs = [cwd];
+  let relPaths = [''];
+
+  for (const part of parts) {
+    const nextDirs = [];
+    const nextRels = [];
+    for (let i = 0; i < dirs.length; i++) {
+      const dir = dirs[i];
+      const rel = relPaths[i];
+      if (!fs.existsSync(dir)) continue;
+      let entries;
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+      catch { continue; }
+      for (const entry of entries) {
+        if (matchSegment(part, entry.name)) {
+          nextDirs.push(path.join(dir, entry.name));
+          nextRels.push(rel ? `${rel}/${entry.name}` : entry.name);
+        }
+      }
+    }
+    dirs = nextDirs;
+    relPaths = nextRels;
+  }
+
+  return dirs.map((d, i) => {
+    try {
+      const stat = fs.statSync(d);
+      return { path: relPaths[i], size: stat.size };
+    } catch { return null; }
+  }).filter(Boolean);
+}
+
+function matchSegment(pattern, name) {
+  if (pattern === '*') return true;
+  const re = new RegExp('^' + pattern.replace(/\./g, '\\.').replace(/\*/g, '.*').replace(/\?/g, '.') + '$');
+  return re.test(name);
+}
 
 function main() {
   if (!fs.existsSync(ACTIVE_FILE)) {
@@ -34,19 +85,16 @@ function main() {
     budget = JSON.parse(fs.readFileSync(BUDGET_FILE, 'utf8'));
   } catch {}
 
+  const cwd = process.cwd();
   const outputs = (contract.contract?.['required-outputs'] || []).map(o => {
     const result = { name: o.name, type: o.type, optional: o.optional || false };
     if (o.pattern) {
-      const resolved = o.pattern;
-      result.path = resolved;
-      try {
-        result.exists = fs.existsSync(path.join(process.cwd(), resolved));
-        if (result.exists) {
-          const stat = fs.statSync(path.join(process.cwd(), resolved));
-          result.size_bytes = stat.size;
-        }
-      } catch {
-        result.exists = false;
+      result.path = o.pattern;
+      const matches = globMatch(o.pattern, cwd);
+      result.exists = matches.length > 0;
+      if (result.exists) {
+        result.matched_files = matches.map(m => m.path);
+        result.size_bytes = matches.reduce((sum, m) => sum + m.size, 0);
       }
     } else {
       const artifactPath = path.join(stateDir, 'outputs', o.name);
@@ -96,11 +144,13 @@ function main() {
   fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
 
-  // Update the index
   const indexPath = path.join(ACOS_DIR, '_index.json');
   let index = [];
   try {
-    index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+    const data = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+    if (Array.isArray(data)) {
+      index = data;
+    }
   } catch {}
   index.push({
     skill: contract.skill,
@@ -111,7 +161,6 @@ function main() {
   });
   fs.writeFileSync(indexPath, JSON.stringify(index, null, 2));
 
-  // Clear active state
   try { fs.unlinkSync(ACTIVE_FILE); } catch {}
   try { fs.unlinkSync(BUDGET_FILE); } catch {}
 

--- a/.claude/hooks/artifact-manager.js
+++ b/.claude/hooks/artifact-manager.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+// NLAH Artifact Manager — Stop hook
+// Seals artifact manifests when a contracted skill session ends.
+// Reads active contract from .acos/artifacts/_active-contract.json,
+// verifies required outputs, writes the final manifest, and clears active state.
+
+const fs = require('fs');
+const path = require('path');
+
+const ACOS_DIR = path.join(process.cwd(), '.acos', 'artifacts');
+const ACTIVE_FILE = path.join(ACOS_DIR, '_active-contract.json');
+const BUDGET_FILE = path.join(ACOS_DIR, '_budget-state.json');
+
+function main() {
+  if (!fs.existsSync(ACTIVE_FILE)) {
+    process.exit(0);
+  }
+
+  let contract;
+  try {
+    contract = JSON.parse(fs.readFileSync(ACTIVE_FILE, 'utf8'));
+  } catch {
+    process.exit(0);
+  }
+
+  const stateDir = contract.stateDir;
+  if (!stateDir || !fs.existsSync(stateDir)) {
+    process.exit(0);
+  }
+
+  let budget = { tool_calls: 0, file_edits: 0, child_agents: 0 };
+  try {
+    budget = JSON.parse(fs.readFileSync(BUDGET_FILE, 'utf8'));
+  } catch {}
+
+  const outputs = (contract.contract?.['required-outputs'] || []).map(o => {
+    const result = { name: o.name, type: o.type, optional: o.optional || false };
+    if (o.pattern) {
+      const resolved = o.pattern;
+      result.path = resolved;
+      try {
+        result.exists = fs.existsSync(path.join(process.cwd(), resolved));
+        if (result.exists) {
+          const stat = fs.statSync(path.join(process.cwd(), resolved));
+          result.size_bytes = stat.size;
+        }
+      } catch {
+        result.exists = false;
+      }
+    } else {
+      const artifactPath = path.join(stateDir, 'outputs', o.name);
+      result.exists = fs.existsSync(artifactPath);
+      if (result.exists) {
+        try {
+          result.size_bytes = fs.statSync(artifactPath).size;
+        } catch {}
+      }
+    }
+    return result;
+  });
+
+  const requiredMet = outputs
+    .filter(o => !o.optional)
+    .every(o => o.exists);
+
+  const budgetLimits = contract.contract?.budget || {};
+  const manifest = {
+    skill: contract.skill,
+    session_id: contract.sessionId,
+    contract_version: '1.0',
+    started_at: budget.started_at || null,
+    completed_at: new Date().toISOString(),
+    status: requiredMet ? 'completed' : 'partial',
+    required_outputs: outputs,
+    completion_conditions_met: requiredMet,
+    budget_usage: {
+      tool_calls: {
+        used: budget.tool_calls || 0,
+        limit: budgetLimits['max-tool-calls'] || null,
+      },
+      file_edits: {
+        used: budget.file_edits || 0,
+        limit: budgetLimits['max-file-edits'] || null,
+      },
+      child_agents: {
+        used: budget.child_agents || 0,
+        limit: budgetLimits['max-child-agents'] || null,
+      },
+    },
+    parent_session: null,
+    child_sessions: [],
+  };
+
+  const manifestPath = path.join(stateDir, contract.contract?.artifacts?.manifest || 'artifact-manifest.json');
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+  // Update the index
+  const indexPath = path.join(ACOS_DIR, '_index.json');
+  let index = [];
+  try {
+    index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+  } catch {}
+  index.push({
+    skill: contract.skill,
+    session_id: contract.sessionId,
+    status: manifest.status,
+    completed_at: manifest.completed_at,
+    state_dir: stateDir,
+  });
+  fs.writeFileSync(indexPath, JSON.stringify(index, null, 2));
+
+  // Clear active state
+  try { fs.unlinkSync(ACTIVE_FILE); } catch {}
+  try { fs.unlinkSync(BUDGET_FILE); } catch {}
+
+  console.log(`[NLAH] Sealed artifact manifest: ${manifest.status} (${outputs.filter(o => o.exists).length}/${outputs.length} outputs)`);
+}
+
+main();

--- a/.claude/hooks/contract-enforcer.js
+++ b/.claude/hooks/contract-enforcer.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+// NLAH Contract Enforcer — PostToolUse hook
+// Tracks budget usage against active skill contracts and emits warnings.
+// Reads contract from .acos/artifacts/{skill}/_active-contract.json
+// Writes budget state to .acos/artifacts/{skill}/_budget-state.json
+
+const fs = require('fs');
+const path = require('path');
+
+const ACOS_DIR = path.join(process.cwd(), '.acos', 'artifacts');
+const BUDGET_THRESHOLDS = { warning: 0.7, urgent: 0.9, exceeded: 1.0 };
+
+function findActiveContract() {
+  if (!fs.existsSync(ACOS_DIR)) return null;
+  const activeFile = path.join(ACOS_DIR, '_active-contract.json');
+  if (!fs.existsSync(activeFile)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(activeFile, 'utf8'));
+  } catch { return null; }
+}
+
+function readBudgetState(skillName) {
+  const stateFile = path.join(ACOS_DIR, '_budget-state.json');
+  if (!fs.existsSync(stateFile)) {
+    return { tool_calls: 0, file_edits: 0, child_agents: 0, started_at: new Date().toISOString() };
+  }
+  try {
+    return JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  } catch {
+    return { tool_calls: 0, file_edits: 0, child_agents: 0, started_at: new Date().toISOString() };
+  }
+}
+
+function writeBudgetState(state) {
+  const stateFile = path.join(ACOS_DIR, '_budget-state.json');
+  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+  fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+}
+
+function getToolFromEnv() {
+  return process.env.CLAUDE_TOOL_NAME || 'unknown';
+}
+
+function checkBudget(used, limit, name) {
+  if (!limit) return null;
+  const ratio = used / limit;
+  if (ratio >= BUDGET_THRESHOLDS.exceeded) {
+    return `[BUDGET EXCEEDED] ${name}: ${used}/${limit} — finalize artifacts and stop`;
+  }
+  if (ratio >= BUDGET_THRESHOLDS.urgent) {
+    return `[BUDGET URGENT] ${name}: ${used}/${limit} — wrap up immediately`;
+  }
+  if (ratio >= BUDGET_THRESHOLDS.warning) {
+    return `[BUDGET WARNING] ${name}: ${used}/${limit} — prioritize remaining work`;
+  }
+  return null;
+}
+
+function main() {
+  const contract = findActiveContract();
+  if (!contract || !contract.budget) {
+    process.exit(0);
+  }
+
+  const tool = getToolFromEnv();
+  const state = readBudgetState(contract.skill);
+
+  state.tool_calls += 1;
+
+  if (tool === 'Write' || tool === 'Edit') {
+    state.file_edits += 1;
+  }
+  if (tool === 'Agent' || tool === 'Task') {
+    state.child_agents += 1;
+  }
+
+  writeBudgetState(state);
+
+  const budget = contract.budget;
+  const warnings = [
+    checkBudget(state.tool_calls, budget['max-tool-calls'], 'tool-calls'),
+    checkBudget(state.file_edits, budget['max-file-edits'], 'file-edits'),
+    checkBudget(state.child_agents, budget['max-child-agents'], 'child-agents'),
+  ].filter(Boolean);
+
+  if (budget['timeout-minutes'] && state.started_at) {
+    const elapsed = (Date.now() - new Date(state.started_at).getTime()) / 60000;
+    const timeWarning = checkBudget(elapsed, budget['timeout-minutes'], 'timeout');
+    if (timeWarning) warnings.push(timeWarning);
+  }
+
+  if (warnings.length > 0) {
+    console.log(warnings.join('\n'));
+  }
+}
+
+main();

--- a/.claude/hooks/contract-enforcer.js
+++ b/.claude/hooks/contract-enforcer.js
@@ -2,26 +2,27 @@
 
 // NLAH Contract Enforcer — PostToolUse hook
 // Tracks budget usage against active skill contracts and emits warnings.
-// Reads contract from .acos/artifacts/{skill}/_active-contract.json
-// Writes budget state to .acos/artifacts/{skill}/_budget-state.json
+// Reads contract from .acos/artifacts/_active-contract-{sid}.json
+// Writes budget state to .acos/artifacts/_budget-state-{sid}.json
 
 const fs = require('fs');
 const path = require('path');
 
 const ACOS_DIR = path.join(process.cwd(), '.acos', 'artifacts');
+const SESSION_ID = process.env.ACOS_SESSION_ID || process.env.CLAUDE_SESSION_ID || 'default';
 const BUDGET_THRESHOLDS = { warning: 0.7, urgent: 0.9, exceeded: 1.0 };
 
 function findActiveContract() {
   if (!fs.existsSync(ACOS_DIR)) return null;
-  const activeFile = path.join(ACOS_DIR, '_active-contract.json');
+  const activeFile = path.join(ACOS_DIR, `_active-contract-${SESSION_ID}.json`);
   if (!fs.existsSync(activeFile)) return null;
   try {
     return JSON.parse(fs.readFileSync(activeFile, 'utf8'));
   } catch { return null; }
 }
 
-function readBudgetState(skillName) {
-  const stateFile = path.join(ACOS_DIR, '_budget-state.json');
+function readBudgetState() {
+  const stateFile = path.join(ACOS_DIR, `_budget-state-${SESSION_ID}.json`);
   if (!fs.existsSync(stateFile)) {
     return { tool_calls: 0, file_edits: 0, child_agents: 0, started_at: new Date().toISOString() };
   }
@@ -33,7 +34,7 @@ function readBudgetState(skillName) {
 }
 
 function writeBudgetState(state) {
-  const stateFile = path.join(ACOS_DIR, '_budget-state.json');
+  const stateFile = path.join(ACOS_DIR, `_budget-state-${SESSION_ID}.json`);
   fs.mkdirSync(path.dirname(stateFile), { recursive: true });
   fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
 }
@@ -59,12 +60,12 @@ function checkBudget(used, limit, name) {
 
 function main() {
   const contract = findActiveContract();
-  if (!contract || !contract.budget) {
+  if (!contract || !contract.contract?.budget) {
     process.exit(0);
   }
 
   const tool = getToolFromEnv();
-  const state = readBudgetState(contract.skill);
+  const state = readBudgetState();
 
   state.tool_calls += 1;
 
@@ -77,7 +78,7 @@ function main() {
 
   writeBudgetState(state);
 
-  const budget = contract.budget;
+  const budget = contract.contract.budget;
   const warnings = [
     checkBudget(state.tool_calls, budget['max-tool-calls'], 'tool-calls'),
     checkBudget(state.file_edits, budget['max-file-edits'], 'file-edits'),
@@ -85,7 +86,7 @@ function main() {
   ].filter(Boolean);
 
   if (budget['timeout-minutes'] && state.started_at) {
-    const elapsed = (Date.now() - new Date(state.started_at).getTime()) / 60000;
+    const elapsed = Math.round(((Date.now() - new Date(state.started_at).getTime()) / 60000) * 10) / 10;
     const timeWarning = checkBudget(elapsed, budget['timeout-minutes'], 'timeout');
     if (timeWarning) warnings.push(timeWarning);
   }

--- a/.claude/schemas/nlah-contract.schema.json
+++ b/.claude/schemas/nlah-contract.schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://acos.frankx.ai/schemas/nlah-contract.schema.json",
+  "title": "NLAH Execution Contract",
+  "description": "Natural-Language Agent Harness contract schema for ACOS skills. Defines required outputs, budgets, completion conditions, permissions, and artifact configuration. Based on arXiv:2603.25723.",
+  "type": "object",
+  "properties": {
+    "required-outputs": {
+      "description": "Artifacts that must be produced for the harness run to be considered complete.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["file", "artifact", "stdout", "state"],
+            "description": "Output type. 'file' = written to disk, 'artifact' = placed in artifact dir, 'stdout' = printed to user, 'state' = persisted in manifest."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for this output."
+          },
+          "pattern": {
+            "type": "string",
+            "description": "Glob pattern for file outputs (e.g. 'docs/specs/SPEC-*.md')."
+          },
+          "format": {
+            "type": "string",
+            "enum": ["markdown", "json", "yaml", "typescript", "html", "text", "jsonl", "any"],
+            "description": "Expected format of the output."
+          },
+          "description": {
+            "type": "string",
+            "description": "What this output contains and why it matters."
+          },
+          "optional": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, missing output triggers a warning instead of a failure."
+          }
+        },
+        "required": ["type", "name"]
+      }
+    },
+    "completion-conditions": {
+      "description": "Natural-language conditions that must all be true for the harness to declare completion. Evaluated by the in-loop LLM against current state.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "budget": {
+      "description": "Resource constraints for this harness run.",
+      "type": "object",
+      "properties": {
+        "max-tool-calls": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of tool invocations before budget warning."
+        },
+        "max-file-edits": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of Write/Edit operations."
+        },
+        "max-child-agents": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum concurrent child agents (Task/Agent tool)."
+        },
+        "context-budget": {
+          "type": "number",
+          "minimum": 0.1,
+          "maximum": 1.0,
+          "description": "Fraction of context window this skill should consume (0.0-1.0)."
+        },
+        "timeout-minutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Wall-clock timeout for the entire harness run."
+        }
+      }
+    },
+    "permissions": {
+      "description": "Permission scope for this harness. Composes with agent-iam.json via intersection semantics.",
+      "type": "object",
+      "properties": {
+        "iam-profile": {
+          "type": "string",
+          "description": "Reference to an agent-iam.json profile (e.g. 'frontend-engineer', 'content-writer')."
+        },
+        "additional-paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional glob patterns for allowed file paths."
+        },
+        "denied-paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Glob patterns for explicitly denied file paths."
+        },
+        "can-spawn-agents": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether this harness may spawn child agents."
+        },
+        "can-modify-harness": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this harness may modify its own SKILL.md."
+        }
+      }
+    },
+    "artifacts": {
+      "description": "Durable artifact configuration for execution state persistence.",
+      "type": "object",
+      "properties": {
+        "state-dir": {
+          "type": "string",
+          "default": ".acos/artifacts/${skill-name}/${session-id}/",
+          "description": "Template path for artifact storage. Supports ${skill-name} and ${session-id} variables."
+        },
+        "manifest": {
+          "type": "string",
+          "default": "artifact-manifest.json",
+          "description": "Filename for the artifact manifest within state-dir."
+        },
+        "retention": {
+          "type": "string",
+          "pattern": "^\\d+[dhm]$",
+          "default": "30d",
+          "description": "Retention period for artifacts (e.g. '30d', '12h', '60m')."
+        },
+        "execution-log": {
+          "type": "string",
+          "default": "execution-log.jsonl",
+          "description": "Filename for the append-only execution log."
+        }
+      }
+    },
+    "verification": {
+      "description": "How outputs are verified before the harness declares success.",
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": ["existence", "content-check", "script", "llm-judge"],
+          "default": "existence",
+          "description": "Verification method. 'existence' = files exist and non-empty, 'content-check' = LLM validates content against description, 'script' = run a verification script, 'llm-judge' = LLM scores output quality."
+        },
+        "threshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.8,
+          "description": "Minimum verification score (0.0-1.0) for 'llm-judge' method."
+        },
+        "script": {
+          "type": "string",
+          "description": "Path to verification script (for 'script' method)."
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/.claude/skill-rules.json
+++ b/.claude/skill-rules.json
@@ -213,6 +213,15 @@
       "priority": "low"
     },
     {
+      "skill": "nlah-contracts",
+      "triggers": {
+        "keywords": ["contract", "NLAH", "harness", "budget enforcement", "artifact manifest", "execution contract", "required outputs", "completion conditions"],
+        "file_patterns": [".acos/artifacts/**", "nlah-contract.schema.json"],
+        "commands": []
+      },
+      "priority": "medium"
+    },
+    {
       "skill": "cacos",
       "triggers": {
         "keywords": ["cacos", "agentic creator os", "activate system", "ultrawork", "ulw"],

--- a/.claude/skills/nlah-contracts/SKILL.md
+++ b/.claude/skills/nlah-contracts/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: nlah-contracts
+description: "Natural-Language Agent Harness contract system for ACOS. Documents execution contracts, the runtime charter, artifact management, and harness optimization. Use when building new contracted skills, understanding the NLAH system, or debugging contract enforcement. Based on arXiv:2603.25723."
+version: "1.0.0"
+---
+
+# Natural-Language Agent Harness Contracts
+
+ACOS skills are natural-language agent harnesses — workflow specifications written in editable markdown, executed by an LLM at runtime. The NLAH contract system formalizes what ACOS does implicitly by adding execution contracts, durable artifacts, and systematic optimization.
+
+Reference: [Natural-Language Agent Harnesses (arXiv:2603.25723)](https://arxiv.org/abs/2603.25723)
+
+## Core Concepts
+
+### 1. Execution Contract
+
+An optional `contract:` block in SKILL.md frontmatter that declares:
+
+- **Required outputs** — what must be produced (files, artifacts, state)
+- **Completion conditions** — natural-language conditions for "done"
+- **Budget** — resource caps (tool calls, file edits, child agents, context, time)
+- **Permissions** — scope composing with agent-iam.json
+- **Artifacts** — where execution state is persisted
+
+Skills without a `contract:` block work identically to before. Contracts are additive.
+
+### 2. Runtime Charter
+
+`.claude/RUNTIME_CHARTER.md` defines how the ACOS runtime interprets and enforces contracts. The charter is itself an NLAH — a natural-language specification that Claude reads at session start. It governs:
+
+- Contract interpretation (how conditions are evaluated)
+- Budget enforcement (tool-call counting, warnings, stops)
+- Child agent lifecycle (spawning, inheritance, failure)
+- Artifact management (creation, sealing, retention)
+
+### 3. Durable Artifacts
+
+Every contracted skill run produces inspectable artifacts in `.acos/artifacts/`:
+
+```
+.acos/artifacts/{skill-name}/{session-id}/
+├── artifact-manifest.json     # What was produced, budget usage, scores
+├── contract-snapshot.json     # The contract that governed this run
+├── execution-log.jsonl        # Append-only tool call log
+├── outputs/                   # Required outputs
+└── verification/              # Verification results
+```
+
+### 4. Harness Optimization
+
+Feedback Descent loops iteratively improve skill definitions by comparing artifact manifests from variant runs on the same task.
+
+## Adding a Contract to an Existing Skill
+
+Add a `contract:` block to SKILL.md frontmatter. Schema: `.claude/schemas/nlah-contract.schema.json`
+
+### Minimal Contract
+
+```yaml
+contract:
+  required-outputs:
+    - type: file
+      name: "plan"
+      pattern: "task_plan.md"
+  completion-conditions:
+    - "All required outputs exist and are non-empty"
+  budget:
+    max-tool-calls: 50
+```
+
+### Full Contract
+
+```yaml
+contract:
+  required-outputs:
+    - type: file
+      name: "specification"
+      pattern: "docs/specs/SPEC-*.md"
+      format: markdown
+      description: "Feature specification document"
+    - type: artifact
+      name: "implementation-plan"
+      format: markdown
+      description: "Ordered list of implementation tasks"
+    - type: file
+      name: "test-plan"
+      pattern: "docs/specs/TEST-*.md"
+      format: markdown
+      optional: true
+  completion-conditions:
+    - "All required outputs exist and are non-empty"
+    - "No verification checks below threshold"
+    - "User confirms acceptance OR auto-accept after verification passes"
+  budget:
+    max-tool-calls: 50
+    max-file-edits: 20
+    max-child-agents: 3
+    context-budget: 0.5
+    timeout-minutes: 30
+  permissions:
+    iam-profile: "frontend-engineer"
+    additional-paths: ["docs/**"]
+    denied-paths: [".env*", "*.key"]
+    can-spawn-agents: true
+    can-modify-harness: false
+  artifacts:
+    state-dir: ".acos/artifacts/${skill-name}/${session-id}/"
+    manifest: "artifact-manifest.json"
+    retention: "30d"
+    execution-log: "execution-log.jsonl"
+  verification:
+    method: "content-check"
+    threshold: 0.8
+```
+
+## Contract Enforcement
+
+Enforcement is soft — Claude reads the charter and respects budget warnings. The `contract-enforcer.js` PostToolUse hook tracks usage and emits signals:
+
+| Budget % | Signal |
+|---|---|
+| 0-70% | Normal operation |
+| 70-90% | Warning: approaching budget limit |
+| 90-100% | Urgent: near budget exhaustion, wrap up |
+| 100%+ | Stop: budget exceeded, finalize artifacts |
+
+The circuit breaker (`circuit-breaker.sh`) serves as a hard backstop.
+
+## Artifact Manifest Format
+
+```json
+{
+  "skill": "planning-with-files",
+  "session_id": "abc123",
+  "contract_version": "1.0",
+  "started_at": "2026-06-22T10:00:00Z",
+  "completed_at": "2026-06-22T10:15:00Z",
+  "status": "completed",
+  "required_outputs": [
+    {
+      "name": "plan",
+      "type": "file",
+      "path": "task_plan.md",
+      "exists": true,
+      "size_bytes": 2400
+    }
+  ],
+  "completion_conditions_met": true,
+  "budget_usage": {
+    "tool_calls": { "used": 34, "limit": 50 },
+    "file_edits": { "used": 8, "limit": 20 },
+    "child_agents": { "used": 1, "limit": 3 }
+  },
+  "verification_score": 0.92,
+  "parent_session": null,
+  "child_sessions": []
+}
+```
+
+## Harness Portability
+
+Because skills are natural-language documents (not code), they're inherently portable. The adapter layer (`.claude/adapters/`) maps abstract harness operations to concrete tool calls per backend:
+
+| Abstract Operation | Claude Code | Cursor | Generic CLI |
+|---|---|---|---|
+| read_file | Read | Read | cat |
+| write_file | Write | Write | echo > |
+| edit_file | Edit | Edit | sed |
+| run_command | Bash | Terminal | sh |
+| spawn_agent | Agent | N/A | subprocess |
+| search_files | Grep + Glob | Search | rg + fd |
+
+## Design Decisions
+
+1. **Contracts in frontmatter, not separate files.** Keeps the one-file-per-skill pattern.
+2. **Artifact dir in `.acos/`, not `.claude/`.** Separates harness definitions (portable) from execution artifacts (project-local).
+3. **Charter as markdown, not code.** The runtime that executes NLAHs is itself described as an NLAH.
+4. **Budget enforcement via hooks, not hard limits.** Soft enforcement through charter awareness + circuit breaker backstop.
+5. **Contracts are opt-in.** No breaking changes to existing skills.

--- a/.claude/skills/planning-with-files/SKILL.md
+++ b/.claude/skills/planning-with-files/SKILL.md
@@ -12,6 +12,46 @@ allowed-tools:
   - Grep
   - WebFetch
   - WebSearch
+contract:
+  required-outputs:
+    - type: file
+      name: "task-plan"
+      pattern: "task_plan.md"
+      format: markdown
+      description: "Structured task plan with phases, status tracking, and completion criteria"
+    - type: file
+      name: "findings"
+      pattern: "findings.md"
+      format: markdown
+      description: "Research findings and key discoveries"
+      optional: true
+    - type: file
+      name: "progress"
+      pattern: "progress.md"
+      format: markdown
+      description: "Execution progress log"
+      optional: true
+  completion-conditions:
+    - "task_plan.md exists and contains at least one phase marked DONE"
+    - "All non-optional required outputs exist and are non-empty"
+  budget:
+    max-tool-calls: 100
+    max-file-edits: 30
+    max-child-agents: 5
+    timeout-minutes: 45
+  permissions:
+    iam-profile: "frontend-engineer"
+    additional-paths: ["docs/**", "*.md"]
+    denied-paths: [".env*", "*.key"]
+    can-spawn-agents: true
+    can-modify-harness: false
+  artifacts:
+    state-dir: ".acos/artifacts/planning-with-files/${session-id}/"
+    manifest: "artifact-manifest.json"
+    retention: "30d"
+    execution-log: "execution-log.jsonl"
+  verification:
+    method: "existence"
 hooks:
   PreToolUse:
     - matcher: "Write|Edit|Bash|Read|Glob|Grep"


### PR DESCRIPTION
## Summary

- **NLAH contract system** for ACOS skills based on [arXiv:2603.25723](https://arxiv.org/abs/2603.25723). Skills can now declare opt-in execution contracts in SKILL.md frontmatter — required outputs, budget limits, permissions, completion conditions, and artifact configuration.
- **Runtime Charter** (`.claude/RUNTIME_CHARTER.md`) defines how contracts are interpreted and enforced at runtime — itself written as a natural-language agent harness.
- **Contract enforcer hook** tracks budget usage (tool calls, file edits, child agents, timeout) and emits graduated warnings (70% → warning, 90% → urgent, 100% → exceeded).
- **Artifact manager hook** seals manifests on session stop — verifies required outputs, writes `artifact-manifest.json`, updates the cross-skill index.
- **Reference implementation** on `planning-with-files` skill demonstrates the contract block pattern.
- **Artifact isolation** via `.acos/.gitignore` keeps execution artifacts out of version control.

## Files Added/Modified

| File | Purpose |
|------|---------|
| `.claude/schemas/nlah-contract.schema.json` | JSON Schema for contract validation |
| `.claude/skills/nlah-contracts/SKILL.md` | System documentation skill |
| `.claude/RUNTIME_CHARTER.md` | Runtime interpretation spec |
| `.claude/hooks/contract-enforcer.js` | PostToolUse budget tracker |
| `.claude/hooks/artifact-manager.js` | Stop hook for manifest sealing |
| `.claude/skill-rules.json` | Added NLAH auto-activation rule |
| `.claude/skills/planning-with-files/SKILL.md` | Reference contract block |
| `.acos/.gitignore` | Artifact isolation |

## Test plan

- [ ] Verify `planning-with-files` skill still activates normally (contract is additive, not breaking)
- [ ] Confirm `.acos/artifacts/` directory is created on contracted skill activation
- [ ] Test budget warning thresholds fire at 70%, 90%, 100% of limits
- [ ] Verify artifact manifest is sealed on session stop
- [ ] Confirm `.acos/` artifacts are excluded from git tracking

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01DxqEuLQdCgt6cbA8c1QCu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxqEuLQdCgt6cbA8c1QCu5)_