### PR TITLE
fix(docs): repair dead hook reference, reconcile agent count and version drift

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -19,9 +19,9 @@
       },
       {
         "name": "skill-rules-loader",
-        "description": "Load enhanced skill-rules-v2.json with enforcement types",
+        "description": "Load skill-rules.json activation rules",
         "type": "command",
-        "command": "test -f .claude/skill-rules-v2.json && echo 'Enhanced skill rules (v2) loaded: confidence scoring, model routing, skip conditions' || echo 'Using standard skill rules'",
+        "command": "test -f .claude/skill-rules.json && echo 'Skill rules loaded: activation patterns for auto-loading skills' || echo 'skill-rules.json missing'",
         "once": true
       },
       {
@@ -74,7 +74,7 @@
         "name": "skill-suggestion",
         "description": "Suggest relevant skills based on recent activity",
         "type": "command",
-        "command": "echo 'SKILL SUGGESTIONS:\\n\\nCheck skill-rules-v2.json for auto-activation matches'"
+        "command": "echo 'SKILL SUGGESTIONS:\\n\\nCheck skill-rules.json for auto-activation matches'"
       }
     ]
   },

--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -74,7 +74,7 @@
         "name": "skill-suggestion",
         "description": "Suggest relevant skills based on recent activity",
         "type": "command",
-        "command": "echo 'SKILL SUGGESTIONS:\\n\\nCheck skill-rules.json for auto-activation matches'"
+        "command": "printf 'SKILL SUGGESTIONS:\\n\\nCheck skill-rules.json for auto-activation matches\\n'"
       }
     ]
   },

--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -12,9 +12,9 @@
     "SessionStart": [
       {
         "name": "acos-context-loader",
-        "description": "Load ACOS v10 with model routing and skill auto-activation",
+        "description": "Load ACOS v11 with model routing and skill auto-activation",
         "type": "command",
-        "command": "echo 'ACOS v10 loaded | Model Routing ON | Skill Auto-Activation ON | Safety Hooks ON'",
+        "command": "echo 'ACOS v11 loaded | Model Routing ON | Skill Auto-Activation ON | Safety Hooks ON'",
         "once": true
       },
       {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Agentic Creator OS v10 — Project Instructions
+# Agentic Creator OS v11 — Project Instructions
 
 > The operating system for AI-powered creators. Multi-platform, self-learning, safety-first.
 
@@ -57,11 +57,11 @@ Instead of blanket word bans, apply these principles:
 
 ## What is ACOS?
 
-**Agentic Creator OS v10** is a skill, agent, and workflow system for AI coding assistants. When loaded, you get:
+**Agentic Creator OS v11** is a skill, agent, and workflow system for AI coding assistants. When loaded, you get:
 
 - **35+ Commands** — Reusable workflows accessible via `/acos` smart router (Claude Code)
 - **75+ Skills** — Auto-activate via `skill-rules.json` based on task context
-- **38 Specialized Agents** — Writers, editors, designers, strategists, engineers
+- **67 Specialized Agents** — Writers, editors, designers, strategists, engineers
 - **v10 Safety Hooks** — Circuit breaker, audit trail, self-modify gate, agent IAM
 
 ## Quick Start
@@ -258,5 +258,5 @@ Before ANY structural change:
 
 ---
 
-*ACOS v10.1 — Autonomous Intelligence*
+*ACOS v11.0 — Autonomous Intelligence*
 *Created by [FrankX](https://github.com/frankxai)*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **The Operating System for AI-Powered Creators**
 
-*One install. Any coding agent. 90+ skills, 65+ commands, 38 agents — auto-activating.*
+*One install. Any coding agent. 90+ skills, 65+ commands, 67 agents — auto-activating.*
 
 ![Agentic Creator OS — FRANK-Ω Command Center](docs/infographics/acos-hero-omega.png)
 
@@ -68,7 +68,7 @@ ACOS (Agentic Creator OS) is the **shared execution layer** (skills + commands +
 | Layer | Role | Key |
 |-------|------|-----|
 | **SIP (Starlight Intelligence Protocol)** | Cross-repo memory, MCP substrate (github/fs-starlight/git), sovereignty, attestation, vaults | starlightintelligence.org/protocol |
-| **ACOS** | 90+ skills, 65+ commands, 38 agents, workflows, v10+ safety (IAM, circuit-breaker, audit, self-modify), auto-activation via skill-rules + excellence | This repo; junctions to ~/.claude + .grok compat |
+| **ACOS** | 90+ skills, 65+ commands, 67 agents, workflows, v10+ safety (IAM, circuit-breaker, audit, self-modify), auto-activation via skill-rules + excellence | This repo; junctions to ~/.claude + .grok compat |
 | **Grok Build (xAI)** | TUI speed, subagents (explore/plan), MCP, image/video, .grok/skills + hooks native + full .claude compat. Personal excellence seeds (4 + 2 json) via grok-harness-adapter | adapters/grok/ + install --platform=grok; .grok-only grok-personal layer only |
 | **Claude Code** | Canonical full surface (slash commands, hooks, IAM, skill-rules) | Direct .claude/ install |
 | **Other (Cursor, Windsurf, Gemini, AGY)** | Context files + embedded skills/agents; delegation via multi-orchestrator | .cursorrules etc. |
@@ -326,7 +326,7 @@ skill-rules.json → 22 pattern rules
   "deploy" + "vercel"   → loads vercel-deployment + nextjs-best-practices
 ```
 
-### Agents (38 Specialized)
+### Agents (67 Specialized)
 
 | Domain | Agents | Examples |
 |--------|--------|----------|
@@ -484,7 +484,7 @@ agentic-creator-os/
 ├── docs/infographics/      # Visual documentation
 ├── install.sh              # Multi-platform installer
 ├── CLAUDE.md               # Claude Code context
-└── package.json            # v10.1.0
+└── package.json            # v11.0.0
 ```
 
 ---
@@ -502,7 +502,7 @@ Starlight Intelligence System (Framework)
      └── ACOS (Claude Code + Grok full harness via grok-harness-adapter + Multi-Platform)
          ├── 35+ commands routed through /acos
          └── Grok: adapters/grok/index.ts + install.sh --platform=grok (GROK.md + .grok/ seeds: excellence, repo-mastery, gstack gates)
-         ├── 38 agents aligned to Starlight council
+         ├── 67 agents aligned to Starlight council
          ├── 75+ auto-activating skills
          ├── v10 safety systems (IAM, circuit breaker, audit)
          └── Self-learning via trajectory patterns
@@ -598,7 +598,7 @@ MIT — Use it, fork it, build your own OS with it.
 
 **Agentic Creator OS v11.0** — The Operating System for AI-Powered Creators
 
-*90+ Skills | 65+ Commands | 38 Agents | 8 Plugins | Multi-Platform | Self-Learning*
+*90+ Skills | 65+ Commands | 67 Agents | 8 Plugins | Multi-Platform | Self-Learning*
 
 Built by [FrankX](https://frankx.ai) — AI Architect & Creator
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ flowchart LR
 |-------|-------------|-------|
 | **Skills** | Domain knowledge modules that load automatically | 75+ |
 | **Commands** | Reusable workflows triggered via slash commands | 35+ |
-| **Agents** | Specialized personas with distinct expertise | 38 |
+| **Agents** | Specialized personas with distinct expertise | 67 |
 | **Safety Hooks** | Circuit breaker, audit trail, IAM, self-modify gate | 5 |
 
 ## Architecture & Harness Role (Whole Stack)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frankx/agentic-creator-os",
   "version": "11.0.0",
-  "description": "The Operating System for AI-Powered Creators — 90+ skills, 65+ commands, 38 agents, 8 plugins. Full support for Claude Code, Grok Build (CLI/TUI via grok-harness-adapter), Cursor, Windsurf, Gemini, Antigravity. Built on SIP.",
+  "description": "The Operating System for AI-Powered Creators — 90+ skills, 65+ commands, 67 agents, 8 plugins. Full support for Claude Code, Grok Build (CLI/TUI via grok-harness-adapter), Cursor, Windsurf, Gemini, Antigravity. Built on SIP.",
   "author": "Frank Guzman <frank@frankx.ai>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Repo audit found operational docs/config drift: a dead hook reference to a nonexistent skill-rules file, and a version/agent-count mismatch between docs and reality. Fixed both.

## Change Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Agent/Skill addition (new agent or skill for ACOS)
- [x] Documentation update
- [ ] CI/Workflow change

## Frank DNA Alignment

- [ ] **Serves the mission** — Helps people build their own systems, not just use someone else's
- [x] **Shows don't tells** — Output volume speaks, not claims
- [x] **Practical value** — Useful over philosophical
- [ ] **Direct voice** — Technical, warm, playful — no corporate speak
- [x] **No AI slop** — Avoids vague spiritual language, unmeasurable claims

## For Structural Changes

<details>
<summary>Structural Change Checklist (expand if applicable)</summary>

**Problem Definition:**
- What specific problem are we solving? Docs (`CLAUDE.md`, `README.md`, `package.json`) claimed "38 Specialized Agents" and "v10/v10.1" while the actual repo has 67 agent files under `.claude/agents/` and `package.json` is already `11.0.0`. Two `.claude/hooks.json` hooks also referenced a `.claude/skill-rules-v2.json` file that has never existed, silently no-op'ing the "enhanced skill rules" enforcement they claimed to load.
- Who has this problem? Anyone reading the docs to understand ACOS's actual scope, and the hook itself (dead code path).
- What's the evidence? `find .claude/agents -maxdepth 1 -iname '*.md'` → 67; `package.json` → `11.0.0`; `test -f .claude/skill-rules-v2.json` → false.

**Solution Evaluation:**
- Is this the simplest solution? Yes — reconcile docs/config to match verified reality, no architecture change.
- Can we configure instead of restructure? N/A, this is a correctness fix.

**Risk Assessment:**
- What could go wrong? Nothing — text/count changes and repointing a hook check to a file that already exists.
- Is this reversible? Yes, trivially.
- SEO or user flow impact? None (internal docs + hook config only).

**The Frank Test:**
1. Does this help someone build their own system? [x] Accurate docs and a working hook > stale numbers and a dead reference.
2. Is it practical over philosophical? [x]
3. Would I be proud to ship this? [x]
4. Is it fun to use? [ ] N/A — it's a docs/hook fix.

</details>

## Testing

- [x] Ran locally and tested the golden path — `node scripts/lint.mjs` passes (18 skills checked, 0 errors, 0 warnings) after every change
- [ ] Tested edge cases
- [ ] Ran existing tests (`npm test` or equivalent) — no test suite covers docs/hooks.json
- [ ] For agents/skills: Validated YAML frontmatter — N/A, no agent/skill files touched
- [x] For workflows: Tested in a fork or draft PR — opened as draft, addressed CodeRabbit/Gemini/Copilot review feedback before marking ready

## Related Issues

None — found via a repo audit, not filed as an issue first.

---

Also flagged during the audit but deliberately **not** touched here (need a human call, not a confident autonomous fix):
- `.claude/skills/skill-rules-v11.json` — orphaned draft in the wrong location, referencing skills that don't exist (`acos`, `baseline-ui`)
- `.claude/skills/anthropic/` — duplicates 14 top-level skills verbatim; unclear if intentional vendoring or drift
- gstack command table in `CLAUDE.md` documents things like `/office-hours` as slash commands, but they're implemented as skills under `.claude/skills/gstack/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)