### PR TITLE
Sync portable model-arena to the multi-provider frontier rebuild

### DIFF
--- a/.claude/workflows/__fixtures__/model-arena-daily.json
+++ b/.claude/workflows/__fixtures__/model-arena-daily.json
@@ -1,16 +1,24 @@
 {
-  "_meta": "Smoke fixture for model-arena-daily. Daily Claude tier comparison.",
-  "args": { "dayOfWeek": 0 },
+  "_meta": "Smoke fixture for model-arena-daily. Multi-provider frontier arena via OpenRouter with in-harness Claude cross-check. Degrades to plan-only when OPENROUTER_API_KEY is absent.",
+  "args": { "date": "2026-07-12", "tasks": 4 },
   "expectedOutputs": {
-    "VERDICT_SCHEMA": {
+    "SYNTH_SCHEMA": {
+      "leader": "Claude Opus 4.8",
+      "biggestMover": "DeepSeek V4",
+      "saturatedAxes": ["instruction-compliance"],
+      "routingImplications": [
+        { "lane": "strict JSON / schema output", "route": "Claude Fable 5", "why": "highest structured-output pass-rate across rounds" },
+        { "lane": "no-tools reasoning", "route": "Claude Opus 4.8", "why": "top pass-rate on the reasoning axis" },
+        { "lane": "cheap grounding / hallucination-resistance", "route": "Gemini 3.5 Flash", "why": "matches flagship pass-rate on grounding at a fraction of the cost" }
+      ]
+    },
+    "JUDGE_SCHEMA": {
+      "winner": "model-B",
       "ranking": [
-        { "tier": "opus", "rank": 1, "strengths": "deepest analysis, most specific examples", "weaknesses": "verbose by ~20%" },
-        { "tier": "sonnet", "rank": 2, "strengths": "tight prose, 95% of Opus depth", "weaknesses": "slightly less novel synthesis" },
-        { "tier": "haiku", "rank": 3, "strengths": "fastest, on-topic", "weaknesses": "shallower trade-off analysis" }
+        { "label": "model-B", "rank": 1, "note": "concrete, states the mechanism, no hype" },
+        { "label": "model-A", "rank": 2, "note": "clean but vaguer" }
       ],
-      "winner": "sonnet",
-      "observations": "Opus and Sonnet near-equivalent on this task class; Sonnet wins on value-per-token",
-      "valueDelta": "Opus not materially better for 250-word framework comparisons; Sonnet is the right default tier"
+      "bannedWordLeak": []
     }
   }
 }

--- a/.claude/workflows/model-arena-daily.js
+++ b/.claude/workflows/model-arena-daily.js
@@ -1,6 +1,6 @@
 export const meta = {
   name: 'model-arena-daily',
-  description: 'Frontier Model Arena. Dispatches an evolving task bank to the top ~13 frontier models (Claude, GPT-5.5, Gemini, Grok, DeepSeek, Qwen, Kimi, Mistral, Gemma, gpt-oss) via OpenRouter, verifies mechanically, judges craft cross-family, and keeps a learning leaderboard. Detects new model releases from the registry. Durable sink: committed receipt + leaderboard + Slack DM.',
+  description: 'Frontier Model Arena. Dispatches an evolving task bank to the top ~13 frontier models (Claude, GPT-5.5, Gemini, Grok, DeepSeek, Qwen, Kimi, Mistral, Gemma, gpt-oss) via OpenRouter, verifies mechanically, judges craft cross-family, and keeps a learning leaderboard. Detects new model releases from the registry. Durable sink: committed receipt + leaderboard (+ best-effort Slack DM where a Slack connector is configured).',
   whenToUse: 'Weekly frontier round (cadence moved from daily → weekly 2026-07-12: 13 models × N tasks is heavy work, and it now feeds a durable receipt + the public /research/model-arena page). Pass args.tasks to set round size, args.week to force rotation, args.date for the receipt name. Runs degraded (plan-only) if OPENROUTER_API_KEY is absent.',
   phases: [
     { title: 'Recall', detail: 'prior rounds from trajectory' },
@@ -11,7 +11,7 @@ export const meta = {
     { title: 'Synthesize', detail: 'leaderboard delta + routing implications' },
     { title: 'Record', detail: 'persist round to trajectory memory' },
     { title: 'Commit', detail: 'commit receipt + leaderboard back to main' },
-    { title: 'Notify', detail: 'Slack DM the standings + learnings' },
+    { title: 'Notify', detail: 'best-effort Slack DM of standings + learnings' },
   ],
   acos: {
     tier: 'L99',
@@ -181,11 +181,12 @@ phase('Commit')
 // if they die in the ephemeral CCR checkout. Commit them back to main.
 await agent(
   `Commit this round's arena artifacts back to main so they survive the ephemeral checkout (durable-output-sink law). ` +
-  `FIRST, if a judge verdict exists (${judge ? 'it does' : 'it does not this round'}), merge it into the receipt so the committed artifact isn't left with pass:null for the craft task: ` +
-  `read data/model-arena/runs/${date}.json, add a top-level "judgeVerdict" field = ${JSON.stringify(judge || null)}, write it back. ` +
-  `THEN stage ONLY these paths: data/model-arena/runs/${date}.json, data/model-arena/leaderboard.json, scripts/model-arena/tasks.json ` +
-  `(tasks.json changed if a task saturated). Commit message: "chore(arena): frontier round ${date} — leader ${synth.leader}". ` +
-  `Then push to the current branch. If nothing changed (degraded/plan run wrote no receipt), skip the commit and say so. ` +
+  (runOut?.mode === 'plan'
+    ? `This was a plan/degraded run (no OPENROUTER_API_KEY): the runner wrote NO receipt and NO leaderboard change, so there is nothing to commit — report that and stop. `
+    : `FIRST${judge ? ', because a judge verdict exists this round,' : ' (no judge verdict this round, so skip straight to staging)'} merge any judge verdict into the receipt so the committed artifact isn't left with pass:null for the craft task: ` +
+      `read data/model-arena/runs/${date}.json, add a top-level "judgeVerdict" field = ${JSON.stringify(judge || null)}, write it back. ` +
+      `THEN stage ONLY these paths: data/model-arena/runs/${date}.json, data/model-arena/leaderboard.json, scripts/model-arena/tasks.json ` +
+      `(tasks.json changed if a task saturated). Commit message: "chore(arena): frontier round ${date} — leader ${synth.leader}", then push to the current branch. `) +
   `Ignore a non-fatal push failure; report what git printed.`,
   { phase: 'Commit', model: 'haiku' }
 ).catch(() => null)

--- a/.claude/workflows/model-arena-daily.js
+++ b/.claude/workflows/model-arena-daily.js
@@ -155,8 +155,10 @@ const synth = await agent(
   `leaderboard=data/model-arena/leaderboard.json, this round's receipt, runner learnings=${JSON.stringify(runOut?.learnings || [])}, ` +
   `new models flagged=${JSON.stringify(newModels?.missing || [])}, cross-check=${JSON.stringify(crossCheck)}, ` +
   `craft-task judge verdict=${JSON.stringify(judge || 'not judged this round')}. ` +
-  `Read the leaderboard, then return: leader (top pass-rate), biggestMover if any, saturatedAxes (from learnings), and 3-4 routingImplications ` +
-  `{lane, route (which model), why} grounded in per-axis pass-rates — e.g. which model to route strict-JSON to, which for reasoning, which for cheap grounding. ` +
+  `Read the leaderboard (each model has elo, passRate, per-axis pass-rates, totalCostUsd, lastAvgLatencyMs), then return: leader (top Elo), ` +
+  `biggestMover if any, saturatedAxes (from learnings), and 3-4 routingImplications ` +
+  `{lane, route (which model), why} grounded in the per-axis pass-rates AND cost/latency — e.g. which model to route strict-JSON to, which for reasoning, ` +
+  `and where a cheaper model ties the flagship (intelligence-per-dollar). ` +
   `Be honest about small-n; this is directional.`,
   { phase: 'Synthesize', schema: SYNTH_SCHEMA, model: 'opus' }
 )

--- a/.claude/workflows/model-arena-daily.js
+++ b/.claude/workflows/model-arena-daily.js
@@ -63,6 +63,36 @@ const SYNTH_SCHEMA = {
   },
 }
 
+const DETECT_SCHEMA = {
+  type: 'object',
+  required: ['missing'],
+  properties: {
+    missing: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'name', 'org'],
+        properties: { id: { type: 'string' }, name: { type: 'string' }, org: { type: 'string' } },
+      },
+    },
+    note: { type: 'string' },
+  },
+}
+
+const DISPATCH_SCHEMA = {
+  type: 'object',
+  required: ['ok', 'mode'],
+  properties: {
+    ok: { type: 'boolean' },
+    mode: { type: 'string' },
+    leader: { type: 'string' },
+    learnings: { type: 'array', items: { type: 'string' } },
+    receipt: { type: 'string' },
+    leaderboard: { type: 'string' },
+    judgeNeeded: { type: 'boolean' },
+  },
+}
+
 const date = args?.date || new Date().toISOString().slice(0, 10)
 const roundSize = args?.tasks || 4
 
@@ -81,7 +111,7 @@ const newModels = await agent(
   `(2) Read scripts/model-arena/roster.json and list every registry_id. ` +
   `(3) Return the GA registry models whose id is NOT in the roster, as {missing: [{id, name, org}], note}. ` +
   `This is how the ring grows as new models release — flag them so a human adds an openrouter_slug and sets arena_active.`,
-  { phase: 'Detect', model: 'haiku' }
+  { phase: 'Detect', schema: DETECT_SCHEMA, model: 'haiku' }
 ).catch(() => ({ missing: [], note: 'detect skipped' }))
 log(`New-model detection: ${(newModels?.missing?.length ?? 0)} GA model(s) not yet in the ring`)
 
@@ -91,7 +121,7 @@ const runOut = await agent(
   `Command: node scripts/model-arena/run.mjs --tasks ${roundSize} --date ${date}\n` +
   `If OPENROUTER_API_KEY is unset the runner returns mode:"plan" degraded:true — that is expected, not a failure; report it as-is. ` +
   `Return the parsed JSON (ok, mode, leader, learnings, receipt, leaderboard paths, judgeNeeded).`,
-  { phase: 'Dispatch', model: 'haiku' }
+  { phase: 'Dispatch', schema: DISPATCH_SCHEMA, model: 'haiku' }
 ).catch((e) => ({ ok: false, error: String(e), mode: 'error' }))
 log(`Arena dispatch: mode=${runOut?.mode} leader=${runOut?.leader ?? 'n/a'}`)
 
@@ -123,7 +153,8 @@ phase('Synthesize')
 const synth = await agent(
   `Synthesize this Model Arena round into routing guidance. Inputs: ` +
   `leaderboard=data/model-arena/leaderboard.json, this round's receipt, runner learnings=${JSON.stringify(runOut?.learnings || [])}, ` +
-  `new models flagged=${JSON.stringify(newModels?.missing || [])}, cross-check=${JSON.stringify(crossCheck)}. ` +
+  `new models flagged=${JSON.stringify(newModels?.missing || [])}, cross-check=${JSON.stringify(crossCheck)}, ` +
+  `craft-task judge verdict=${JSON.stringify(judge || 'not judged this round')}. ` +
   `Read the leaderboard, then return: leader (top pass-rate), biggestMover if any, saturatedAxes (from learnings), and 3-4 routingImplications ` +
   `{lane, route (which model), why} grounded in per-axis pass-rates — e.g. which model to route strict-JSON to, which for reasoning, which for cheap grounding. ` +
   `Be honest about small-n; this is directional.`,
@@ -148,7 +179,9 @@ phase('Commit')
 // if they die in the ephemeral CCR checkout. Commit them back to main.
 await agent(
   `Commit this round's arena artifacts back to main so they survive the ephemeral checkout (durable-output-sink law). ` +
-  `Stage ONLY these paths: data/model-arena/runs/${date}.json, data/model-arena/leaderboard.json, scripts/model-arena/tasks.json ` +
+  `FIRST, if a judge verdict exists (${judge ? 'it does' : 'it does not this round'}), merge it into the receipt so the committed artifact isn't left with pass:null for the craft task: ` +
+  `read data/model-arena/runs/${date}.json, add a top-level "judgeVerdict" field = ${JSON.stringify(judge || null)}, write it back. ` +
+  `THEN stage ONLY these paths: data/model-arena/runs/${date}.json, data/model-arena/leaderboard.json, scripts/model-arena/tasks.json ` +
   `(tasks.json changed if a task saturated). Commit message: "chore(arena): frontier round ${date} — leader ${synth.leader}". ` +
   `Then push to the current branch. If nothing changed (degraded/plan run wrote no receipt), skip the commit and say so. ` +
   `Ignore a non-fatal push failure; report what git printed.`,

--- a/.claude/workflows/model-arena-daily.js
+++ b/.claude/workflows/model-arena-daily.js
@@ -1,84 +1,182 @@
 export const meta = {
   name: 'model-arena-daily',
-  description: 'Daily multi-tier model arena. Runs the same canonical prompt through Claude Opus / Sonnet / Haiku in parallel. Synthesizer ranks responses on depth, accuracy, specificity. Captures regression signal if a tier drops.',
-  whenToUse: 'Daily intelligence on which Claude tier is best for each task type. Cost-disciplined by design: 3 generators + 1 judge = ~40-80k tokens. Pass args.prompt to override the default canonical prompt; pass args.topic to rotate weekly themes.',
+  description: 'Frontier Model Arena. Dispatches an evolving task bank to the top ~13 frontier models (Claude, GPT-5.5, Gemini, Grok, DeepSeek, Qwen, Kimi, Mistral, Gemma, gpt-oss) via OpenRouter, verifies mechanically, judges craft cross-family, and keeps a learning leaderboard. Detects new model releases from the registry. Durable sink: committed receipt + leaderboard + Slack DM.',
+  whenToUse: 'Weekly frontier round (cadence moved from daily → weekly 2026-07-12: 13 models × N tasks is heavy work, and it now feeds a durable receipt + the public /research/model-arena page). Pass args.tasks to set round size, args.week to force rotation, args.date for the receipt name. Runs degraded (plan-only) if OPENROUTER_API_KEY is absent.',
   phases: [
-    { title: 'Generate', detail: '3 parallel tier responses' },
-    { title: 'Judge', detail: 'rank + regression check' },
+    { title: 'Recall', detail: 'prior rounds from trajectory' },
+    { title: 'Detect', detail: 'new registry models missing from the ring' },
+    { title: 'Dispatch', detail: 'run the multi-provider arena via OpenRouter' },
+    { title: 'Cross-check', detail: 'in-harness Claude tiers on one task (always verifiable)' },
+    { title: 'Judge', detail: 'blind cross-family scoring of the craft task' },
+    { title: 'Synthesize', detail: 'leaderboard delta + routing implications' },
+    { title: 'Record', detail: 'persist round to trajectory memory' },
+    { title: 'Commit', detail: 'commit receipt + leaderboard back to main' },
+    { title: 'Notify', detail: 'Slack DM the standings + learnings' },
   ],
   acos: {
     tier: 'L99',
-    cadence: 'daily',
+    cadence: 'weekly',
     portable: true,
     runtime: 'hybrid',
     composes: [],
     composedBy: [],
-    estimatedCost: { min: 40000, max: 90000 },
+    estimatedCost: { min: 60000, max: 140000 },
   },
 }
 
-const VERDICT_SCHEMA = {
+const JUDGE_SCHEMA = {
   type: 'object',
-  required: ['ranking', 'winner', 'observations'],
+  required: ['winner', 'ranking'],
   properties: {
+    winner: { type: 'string' },
     ranking: {
       type: 'array',
       items: {
         type: 'object',
-        required: ['tier', 'rank', 'strengths'],
+        required: ['label', 'rank', 'note'],
         properties: {
-          tier: { enum: ['opus', 'sonnet', 'haiku'] },
-          rank: { type: 'integer', minimum: 1, maximum: 3 },
-          strengths: { type: 'string' },
-          weaknesses: { type: 'string' },
+          label: { type: 'string' },
+          rank: { type: 'integer', minimum: 1 },
+          note: { type: 'string' },
         },
       },
     },
-    winner: { enum: ['opus', 'sonnet', 'haiku'] },
-    observations: { type: 'string' },
-    valueDelta: { type: 'string' },
+    bannedWordLeak: { type: 'array', items: { type: 'string' } },
   },
 }
 
-const ROTATING_TOPICS = [
-  'Explain trade-offs of multi-agent orchestration vs single-agent reasoning for production AI. 250 words. Cite concrete examples.',
-  'Design a token-efficient retrieval pattern for a knowledge base with 1M documents. 250 words. Include cache strategy.',
-  'Compare React Server Components vs Client Components for a real-time dashboard. 250 words. Specific failure modes.',
-  'When is a multi-step workflow better than a single Opus call? 250 words. Three concrete decision criteria.',
-  'How would you architect a self-improving agent system that learns from its own runs? 250 words. Failure modes.',
-  'Critique the prompt: "Be helpful and friendly." Improve it for a tier-2 support agent. 250 words.',
-  'Explain how to prevent hallucinated function calls in tool-use agents. 250 words. Citation discipline.',
-]
+const SYNTH_SCHEMA = {
+  type: 'object',
+  required: ['leader', 'routingImplications'],
+  properties: {
+    leader: { type: 'string' },
+    biggestMover: { type: 'string' },
+    saturatedAxes: { type: 'array', items: { type: 'string' } },
+    routingImplications: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['lane', 'route', 'why'],
+        properties: { lane: { type: 'string' }, route: { type: 'string' }, why: { type: 'string' } },
+      },
+    },
+  },
+}
 
-const dayOfWeek = args?.dayOfWeek ?? 0
-const canonicalPrompt = args?.prompt ?? ROTATING_TOPICS[dayOfWeek % ROTATING_TOPICS.length]
+const date = args?.date || new Date().toISOString().slice(0, 10)
+const roundSize = args?.tasks || 4
 
-phase('Generate')
-const tiers = ['opus', 'sonnet', 'haiku']
-const responses = await parallel(tiers.map(tier => () =>
-  agent(canonicalPrompt, { label: `tier:${tier}`, phase: 'Generate', model: tier })
+phase('Recall')
+const priorRuns = await agent(
+  `Run: node scripts/workflow-trajectory.mjs recall --workflow model-arena-daily --limit 6\n` +
+  `Return JSON. Prior rounds show which axes have saturated and which models led — context, not a thumb on today's scale.`,
+  { phase: 'Recall', model: 'haiku' }
+).catch(() => ({ summary: 'cold start — no prior arena', lessonsLearned: [] }))
+log(`Trajectory: ${priorRuns?.summary || 'cold start'}`)
+
+phase('Detect')
+const newModels = await agent(
+  `Detect frontier models that have shipped but aren't in the arena yet. Steps: ` +
+  `(1) Read data/model-registry.json and list every model with status "ga". ` +
+  `(2) Read scripts/model-arena/roster.json and list every registry_id. ` +
+  `(3) Return the GA registry models whose id is NOT in the roster, as {missing: [{id, name, org}], note}. ` +
+  `This is how the ring grows as new models release — flag them so a human adds an openrouter_slug and sets arena_active.`,
+  { phase: 'Detect', model: 'haiku' }
+).catch(() => ({ missing: [], note: 'detect skipped' }))
+log(`New-model detection: ${(newModels?.missing?.length ?? 0)} GA model(s) not yet in the ring`)
+
+phase('Dispatch')
+const runOut = await agent(
+  `Run the multi-provider Model Arena and report its JSON output verbatim. ` +
+  `Command: node scripts/model-arena/run.mjs --tasks ${roundSize} --date ${date}\n` +
+  `If OPENROUTER_API_KEY is unset the runner returns mode:"plan" degraded:true — that is expected, not a failure; report it as-is. ` +
+  `Return the parsed JSON (ok, mode, leader, learnings, receipt, leaderboard paths, judgeNeeded).`,
+  { phase: 'Dispatch', model: 'haiku' }
+).catch((e) => ({ ok: false, error: String(e), mode: 'error' }))
+log(`Arena dispatch: mode=${runOut?.mode} leader=${runOut?.leader ?? 'n/a'}`)
+
+phase('Cross-check')
+// Always-verifiable core: even if OpenRouter is down, the in-harness Claude tiers
+// run. Same reasoning task the public arena uses; ground truth fixed by the harness.
+const crossTask = 'Find the smallest positive integer divisible by every integer from 1 to 7 but NOT divisible by 8. Reply with ONLY the number.'
+const tiers = ['opus', 'sonnet', 'haiku', 'fable']
+const crossResponses = await parallel(tiers.map((t) => () =>
+  agent(crossTask, { label: `harness:${t}`, phase: 'Cross-check', model: t }).catch(() => null)
 ))
-
-const valid = responses.map((r, i) => ({ tier: tiers[i], response: r })).filter(r => r.response)
-log(`${valid.length}/${tiers.length} tier responses captured for prompt: "${canonicalPrompt.slice(0, 60)}..."`)
+const crossCheck = tiers.map((t, i) => ({ tier: t, answer: (crossResponses[i] || '').trim(), correct: /(^|\D)420(\D|$)/.test(crossResponses[i] || '') }))
+log(`In-harness cross-check: ${crossCheck.filter((c) => c.correct).length}/${tiers.length} Claude tiers got the reasoning task`)
 
 phase('Judge')
-const verdict = await agent(
-  `Compare these 3 Claude-tier responses to the prompt: "${canonicalPrompt}"\n\n` +
-  valid.map(r => `## ${r.tier.toUpperCase()}\n${r.response}`).join('\n\n') +
-  `\n\nJudge on: (1) accuracy of claims, (2) depth of analysis, (3) specificity (concrete examples vs generic), (4) signal-to-noise. ` +
-  `Rank 1-3. Pick winner. Observations on what differentiates them today. ` +
-  `valueDelta: is the Opus output materially better than Sonnet/Haiku, or is the cheaper tier good enough for this task class?`,
-  { phase: 'Judge', schema: VERDICT_SCHEMA, model: 'opus' }
+// Cross-family blind judge for the craft task (kills Claude-family bias).
+const judge = runOut?.judgeNeeded
+  ? await agent(
+      `Blind-judge the craft task from this round's receipt (${runOut?.receipt || 'data/model-arena/runs/' + date + '.json'}). ` +
+      `Read the receipt; find the judge-type task ("judgment-brand-voice") if its per-model outputs are present, otherwise judge is informational only. ` +
+      `First MECHANICALLY reject any rewrite containing the banned hype words (unlock, seamless, supercharge, delve, elevate) or exceeding 25 words — list them in bannedWordLeak. ` +
+      `Then rank the surviving rewrites on concreteness and whether they say something real. Use shuffled labels; do not favor any family. ` +
+      `Return winner + ranking.`,
+      { phase: 'Judge', schema: JUDGE_SCHEMA, model: 'opus' }
+    ).catch(() => null)
+  : null
+
+phase('Synthesize')
+const synth = await agent(
+  `Synthesize this Model Arena round into routing guidance. Inputs: ` +
+  `leaderboard=data/model-arena/leaderboard.json, this round's receipt, runner learnings=${JSON.stringify(runOut?.learnings || [])}, ` +
+  `new models flagged=${JSON.stringify(newModels?.missing || [])}, cross-check=${JSON.stringify(crossCheck)}. ` +
+  `Read the leaderboard, then return: leader (top pass-rate), biggestMover if any, saturatedAxes (from learnings), and 3-4 routingImplications ` +
+  `{lane, route (which model), why} grounded in per-axis pass-rates — e.g. which model to route strict-JSON to, which for reasoning, which for cheap grounding. ` +
+  `Be honest about small-n; this is directional.`,
+  { phase: 'Synthesize', schema: SYNTH_SCHEMA, model: 'opus' }
 )
 
+phase('Record')
+const runId = args?.runId || `model-arena-${date}`
+await agent(
+  `Record this arena round so next week's Recall has real history. ` +
+  `Run: node scripts/workflow-trajectory.mjs record --workflow model-arena-daily ` +
+  `--runId ${runId} --outcome ${runOut?.ok ? 'success' : runOut?.mode === 'plan' ? 'partial' : 'failed'} ` +
+  `--findings ${(synth.routingImplications || []).length} ` +
+  `--summary "Round ${date}: leader ${synth.leader} — ${(synth.routingImplications?.[0]?.lane || '')}" ` +
+  `--lessonsLearned "leader:${synth.leader}|saturated:${(synth.saturatedAxes || []).join(',')}|newModels:${(newModels?.missing || []).map((m) => m.id).join(',')}"\n` +
+  `The command commits the trajectory file back to main — ignore a non-fatal push failure, report what it printed.`,
+  { phase: 'Record', model: 'haiku' }
+).catch(() => null)
+
+phase('Commit')
+// Durable sink #1: the receipt + leaderboard + evolved task bank are worthless
+// if they die in the ephemeral CCR checkout. Commit them back to main.
+await agent(
+  `Commit this round's arena artifacts back to main so they survive the ephemeral checkout (durable-output-sink law). ` +
+  `Stage ONLY these paths: data/model-arena/runs/${date}.json, data/model-arena/leaderboard.json, scripts/model-arena/tasks.json ` +
+  `(tasks.json changed if a task saturated). Commit message: "chore(arena): frontier round ${date} — leader ${synth.leader}". ` +
+  `Then push to the current branch. If nothing changed (degraded/plan run wrote no receipt), skip the commit and say so. ` +
+  `Ignore a non-fatal push failure; report what git printed.`,
+  { phase: 'Commit', model: 'haiku' }
+).catch(() => null)
+
+phase('Notify')
+// Durable sink #2: Slack DM so the standings reach a human, not just run-history.
+await agent(
+  `Post a Slack DM to user U09CE1K62AY (Frank) with this week's Model Arena result. Use the Slack MCP tool (search for it if needed). Content: ` +
+  `"**Model Arena — ${date}** (${runOut?.mode === 'plan' ? '🟡 degraded: no OPENROUTER_API_KEY, plan only' : '🟢 live'})\n` +
+  `Leader: ${synth.leader}${synth.biggestMover ? ' · mover: ' + synth.biggestMover : ''}\n` +
+  `${(newModels?.missing?.length ?? 0) > 0 ? '🆕 ' + newModels.missing.length + ' new GA model(s) to add: ' + newModels.missing.map((m) => m.name).join(', ') + '\n' : ''}` +
+  `${(synth.saturatedAxes?.length ?? 0) > 0 ? '⚠️ saturated axes (harden): ' + synth.saturatedAxes.join(', ') + '\n' : ''}` +
+  `Route: ${(synth.routingImplications || []).slice(0, 2).map((r) => r.lane + '→' + r.route).join(' · ')}\n` +
+  `Receipt: data/model-arena/runs/${date}.json" ` +
+  `If the Slack tool errors (not connected), don't fail the workflow — note it in your return.`,
+  { phase: 'Notify', model: 'haiku' }
+).catch(() => null)
+
 return {
-  date: args?.date,
-  prompt: canonicalPrompt,
-  topicIndex: dayOfWeek % ROTATING_TOPICS.length,
-  winner: verdict.winner,
-  ranking: verdict.ranking,
-  observations: verdict.observations,
-  valueDelta: verdict.valueDelta,
-  responsesCount: valid.length,
+  date,
+  mode: runOut?.mode,
+  leader: synth.leader,
+  routingImplications: synth.routingImplications,
+  saturatedAxes: synth.saturatedAxes || [],
+  newModelsToAdd: newModels?.missing || [],
+  crossCheck,
+  judge: judge || null,
+  receipt: `data/model-arena/runs/${date}.json`,
 }

--- a/data/model-arena/leaderboard.json
+++ b/data/model-arena/leaderboard.json
@@ -1,0 +1,6 @@
+{
+  "_description": "Model Arena standings — updated by scripts/model-arena/run.mjs each round. Directional (n=1 per task/model/round), not statistics. Seeded empty; fills on first real or simulated round.",
+  "rounds": 0,
+  "updated": null,
+  "models": {}
+}

--- a/data/model-arena/leaderboard.json
+++ b/data/model-arena/leaderboard.json
@@ -1,5 +1,5 @@
 {
-  "_description": "Model Arena standings — updated by scripts/model-arena/run.mjs each round. Directional (n=1 per task/model/round), not statistics. Seeded empty; fills on first real or simulated round.",
+  "_description": "Model Arena standings — pass-rate + pairwise Elo + cost/latency, updated by scripts/model-arena/run.mjs each round. Directional (small-n), not statistics. Seeded empty; fills on first real or simulated round.",
   "rounds": 0,
   "updated": null,
   "models": {}

--- a/scripts/model-arena/README.md
+++ b/scripts/model-arena/README.md
@@ -1,0 +1,92 @@
+# Model Arena — multi-provider runner
+
+> Head-to-head evals across the **top frontier models** (not just Claude), on an
+> **evolving** task bank, that **learns** from every round. Feeds the
+> `model-arena-daily` workflow and, on curation, the public
+> `frankx.ai/research/model-arena` page.
+
+## Why this exists (and why the old arena was Claude-only)
+
+The Claude Code Agent/Workflow harness can only spawn **Claude** models via the
+`model` override (`fable` / `opus` / `sonnet` / `haiku`). That is the whole
+reason the previous `model-arena-daily` workflow compared only Claude tiers — it
+was a platform limit, not a choice. To put GPT-5.5, Gemini, Grok, DeepSeek,
+Qwen, Kimi, and Mistral in the same ring you need an external gateway.
+
+This runner uses **OpenRouter** — the sanctioned LLM route in `CLAUDE.md`
+(`OPENROUTER_API_KEY` + `OPENROUTER_BASE_URL`) — to dispatch the same task to
+every model, verify mechanically, and keep a leaderboard.
+
+## Files
+
+| File | Role |
+|---|---|
+| `roster.json` | Who's in the ring. Registry-id → OpenRouter slug + `arena_active`. Source of truth for **who competes** (the registry stays source of truth for model **facts**). |
+| `tasks.json` | The **evolving** task bank. Meaningful capability axes, mostly self-verifying, with per-task `state` + `history` for the learning loop. |
+| `run.mjs` | The runner: rotate tasks → dispatch → verify → receipt → leaderboard → learn. |
+| `../../data/model-arena/leaderboard.json` | Standings (pass-rate per model, per axis). Written by the runner. |
+| `../../data/model-arena/runs/<date>.json` | Per-round receipt (the durable output). |
+
+## Running
+
+```bash
+node scripts/model-arena/run.mjs --check       # validate roster + tasks, exit
+node scripts/model-arena/run.mjs --plan         # print the round plan, no dispatch
+node scripts/model-arena/run.mjs --simulate     # full pipeline with canned responses (no network) — CI/verification
+node scripts/model-arena/run.mjs                # live dispatch via OpenRouter (needs OPENROUTER_API_KEY)
+#   flags: --tasks N (round size, default 4) · --week N (rotation seed) · --date YYYY-MM-DD
+```
+
+Without `OPENROUTER_API_KEY` a live run **degrades** to plan-only (`mode:plan`,
+`degraded:true`) instead of failing — so a CCR routine never hard-errors on a
+missing key; it reports what it *would* have run.
+
+## The learning loop
+
+1. Each round records `{date, passRate}` into every scored task's `history`.
+2. When a task's pass-rate is ≥ `saturation_threshold` (0.95) across
+   `saturation_rounds` (2) consecutive rounds, it flips to `state: saturated`
+   and the runner emits a **"harden this axis"** learning. Saturated tasks stop
+   being dispatched — a saturated task teaches nothing.
+3. **New model releases** feed the roster: the `model-arena-daily` workflow
+   diffs `data/model-registry.json` (maintained by `/new-model`) against
+   `roster.json` and flags any GA model missing from the ring.
+
+That's the two-sided evolution the arena needs: tasks get harder as models
+saturate them; the field grows as new models ship.
+
+## Verifiers
+
+`run.mjs` scores objective tasks mechanically — no LLM judge can launder a
+constraint violation:
+
+`numeric` · `exact` · `contains` · `not_contains` · `regex` · `word_count`
+(count + lowercase + no-punct) · `json_schema` (parse + required keys + tag
+count + lowercase + no-prose).
+
+`judge` tasks return `pass:null` from the script and are scored by a **blind,
+cross-family** judge (default `openai/gpt-5.5`) in the workflow layer — killing
+the Claude-family-bias caveat the public arena has carried. Per arena task-design
+rules, judged tasks stay ≤ half the card.
+
+## Maintenance
+
+- **Slugs drift.** `openrouter_slug` is best-effort; verify against
+  <https://openrouter.ai/models>. A bad slug is recorded as a per-model dispatch
+  error for that round, never a silent fail of the model.
+- **Adding a model:** add a row to `roster.json` (or let new-model detection
+  flag it), set `arena_active` once it has a hosted endpoint.
+- **Adding a task:** append to `tasks.json` with `state:"active"`, a mechanical
+  `verifier` where possible, and a `caveat` stating the ground truth.
+
+## Honest caveats (they ship in every receipt)
+
+- n=1 per (task, model, round) — directional, not statistical. Promote a claim
+  only after repeated rounds agree.
+- This measures **model-via-OpenRouter at temperature 0**, not
+  model-in-Claude-Code-harness. The workflow keeps a separate in-harness Claude
+  cross-check so both views exist.
+- Registry benchmark numbers are vendor-claimed until independently reproduced;
+  the arena's own pass-rates are first-party but small-n.
+
+Built on SIP.

--- a/scripts/model-arena/README.md
+++ b/scripts/model-arena/README.md
@@ -24,7 +24,7 @@ every model, verify mechanically, and keep a leaderboard.
 | `roster.json` | Who's in the ring. Registry-id → OpenRouter slug + `arena_active`. Source of truth for **who competes** (the registry stays source of truth for model **facts**). |
 | `tasks.json` | The **evolving** task bank. Meaningful capability axes, mostly self-verifying, with per-task `state` + `history` for the learning loop. |
 | `run.mjs` | The runner: rotate tasks → dispatch → verify → receipt → leaderboard → learn. |
-| `../../data/model-arena/leaderboard.json` | Standings (pass-rate per model, per axis). Written by the runner. |
+| `../../data/model-arena/leaderboard.json` | Standings — Elo + pass-rate + cost/latency/tokens per model (and per axis). Written by the runner. |
 | `../../data/model-arena/runs/<date>.json` | Per-round receipt (the durable output). |
 
 ## Running
@@ -34,12 +34,46 @@ node scripts/model-arena/run.mjs --check       # validate roster + tasks, exit
 node scripts/model-arena/run.mjs --plan         # print the round plan, no dispatch
 node scripts/model-arena/run.mjs --simulate     # full pipeline with canned responses (no network) — CI/verification
 node scripts/model-arena/run.mjs                # live dispatch via OpenRouter (needs OPENROUTER_API_KEY)
-#   flags: --tasks N (round size, default 4) · --week N (rotation seed) · --date YYYY-MM-DD
+#   flags: --tasks N (round size, default 4) · --week N (rotation seed) · --date YYYY-MM-DD · --concurrency N (default 6)
 ```
 
 Without `OPENROUTER_API_KEY` a live run **degrades** to plan-only (`mode:plan`,
 `degraded:true`) instead of failing — so a CCR routine never hard-errors on a
 missing key; it reports what it *would* have run.
+
+## Rating method (why Elo, not just pass-rate)
+
+Raw pass-rate is a weak signal once the field is large and capability is
+saturated — many models tie at 100%, and it says nothing about *relative*
+strength. So the runner also computes a persistent **pairwise Elo rating**, the
+same family of method LMArena / Chatbot Arena use:
+
+- For each task, every ordered pair of models produces a win / loss / tie from
+  their pass/fail outcomes.
+- Each comparison nudges both models' Elo (start 1000, K=24), seeded from the
+  prior leaderboard so ratings compound across rounds.
+- The leaderboard reports both `elo` and `passRate`; the receipt's `standings`
+  are ranked by Elo. Early ratings are volatile — trust them after several rounds.
+
+## Cost / latency / token telemetry
+
+Every dispatch records latency and token usage (and cost when the gateway
+returns it, via `usage:{include:true}`). The leaderboard carries
+`lastAvgLatencyMs`, `totalTokens`, and `totalCostUsd` per model — so routing can
+optimize **intelligence-per-dollar**, not just accuracy. Telemetry is
+best-effort: 0 when the gateway omits usage (and in `--simulate`).
+
+## Robustness
+
+- **Bounded concurrency** (`--concurrency`, default 6): all (task × model)
+  dispatches run through a small zero-dependency async pool — fast without
+  hammering the gateway.
+- **Retry with backoff**: transient gateway errors (timeout, HTTP 5xx, 429)
+  retry up to 3× (0.5s, 1s). A hard error is recorded as that model's result for
+  the round, never a crash.
+- **Zero runtime dependencies**: the runner uses only Node built-ins (global
+  `fetch`, `node:timers/promises`). Nothing to install; nothing added to the
+  app's dependency tree or lockfile.
 
 ## The learning loop
 

--- a/scripts/model-arena/roster.json
+++ b/scripts/model-arena/roster.json
@@ -1,0 +1,29 @@
+{
+  "_description": "Model Arena roster — which frontier models compete, and how to reach them. Derived from data/model-registry.json but adds the API-dispatch layer (OpenRouter slugs + arena_active). The registry is the source of truth for model FACTS; this roster is the source of truth for who's IN THE RING.",
+  "_maintained_by": "model-arena-daily workflow (new-model detection auto-flags registry GA models missing here) + manual review",
+  "_reachability_note": "openrouter_slug is best-effort and MUST be verified against https://openrouter.ai/models — slugs drift. The runner skips a model with a bad slug and records the error rather than failing the round. Self-host-only and preview models are arena_active:false until a hosted endpoint exists.",
+  "_updated": "2026-07-12",
+  "judge": {
+    "_note": "Blind cross-family judge for subjective tasks. Prefer a non-Anthropic model to kill the family-bias caveat the public arena has carried since 2026-06-09.",
+    "primary_slug": "openai/gpt-5.5",
+    "fallback_harness_model": "sonnet"
+  },
+  "models": [
+    { "registry_id": "claude-opus-4-8", "name": "Claude Opus 4.8", "org": "anthropic", "openrouter_slug": "anthropic/claude-opus-4.8", "harness_model": "opus", "arena_active": true, "tier": "flagship" },
+    { "registry_id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "org": "anthropic", "openrouter_slug": "anthropic/claude-sonnet-4.6", "harness_model": "sonnet", "arena_active": true, "tier": "workhorse" },
+    { "registry_id": "claude-haiku-4-5", "name": "Claude Haiku 4.5", "org": "anthropic", "openrouter_slug": "anthropic/claude-haiku-4.5", "harness_model": "haiku", "arena_active": true, "tier": "fast" },
+    { "registry_id": "claude-fable-5", "name": "Claude Fable 5", "org": "anthropic", "openrouter_slug": "anthropic/claude-fable-5", "harness_model": "fable", "arena_active": true, "tier": "flagship" },
+    { "registry_id": "gpt-5-5", "name": "GPT-5.5", "org": "openai", "openrouter_slug": "openai/gpt-5.5", "arena_active": true, "tier": "flagship" },
+    { "registry_id": "gemini-3-5-flash", "name": "Gemini 3.5 Flash", "org": "google", "openrouter_slug": "google/gemini-3.5-flash", "arena_active": true, "tier": "workhorse" },
+    { "registry_id": "grok-4-3", "name": "Grok 4.3", "org": "xai", "openrouter_slug": "x-ai/grok-4.3", "arena_active": true, "tier": "workhorse" },
+    { "registry_id": "deepseek-v4", "name": "DeepSeek V4", "org": "deepseek", "openrouter_slug": "deepseek/deepseek-v4", "arena_active": true, "tier": "open-frontier" },
+    { "registry_id": "qwen3-7-max", "name": "Qwen3.7-Max", "org": "alibaba", "openrouter_slug": "qwen/qwen3.7-max", "arena_active": true, "tier": "open-frontier" },
+    { "registry_id": "kimi-k2-6", "name": "Kimi K2.6", "org": "moonshot", "openrouter_slug": "moonshotai/kimi-k2.6", "arena_active": true, "tier": "open-frontier" },
+    { "registry_id": "mistral-large-3", "name": "Mistral Large 3", "org": "mistralai", "openrouter_slug": "mistralai/mistral-large-3", "arena_active": true, "tier": "open-frontier" },
+    { "registry_id": "gemma-4", "name": "Gemma 4", "org": "google", "openrouter_slug": "google/gemma-4-31b", "arena_active": true, "tier": "open-local" },
+    { "registry_id": "gpt-oss", "name": "gpt-oss-120b", "org": "openai", "openrouter_slug": "openai/gpt-oss-120b", "arena_active": true, "tier": "open-local" },
+    { "registry_id": "llama-4-maverick", "name": "Llama 4 Maverick", "org": "meta", "openrouter_slug": "meta-llama/llama-4-maverick", "arena_active": false, "tier": "open-local", "inactive_reason": "verified benchmarks now trail the open-frontier tier; keep as a reference baseline, not a live contestant" },
+    { "registry_id": "gemini-3-5-pro", "name": "Gemini 3.5 Pro", "org": "google", "openrouter_slug": "google/gemini-3.5-pro", "arena_active": false, "tier": "flagship", "inactive_reason": "limited preview as of 2026-06 — no GA endpoint; activate on GA" },
+    { "registry_id": "mai-thinking-1", "name": "MAI-Thinking-1", "org": "microsoft", "openrouter_slug": null, "arena_active": false, "tier": "flagship", "inactive_reason": "preview, vendor-claimed benchmarks, no public API endpoint" }
+  ]
+}

--- a/scripts/model-arena/run.mjs
+++ b/scripts/model-arena/run.mjs
@@ -49,14 +49,22 @@ const readJson = async (p) => JSON.parse(await readFile(p, 'utf8'))
 // ── Mechanical verifiers ──────────────────────────────────────────────────
 // Each returns { pass: boolean, note: string }. `judge` tasks are not scored
 // here — they return pass:null so the workflow layer routes them to the judge.
-const PUNCT_RE = /[.,!?;:'"`~@#$%^&*()\[\]{}<>/\\|+=_-]/
+const PUNCT_RE = /[.,!?;:'"`~@#$%^&*()\[\]{}<>\/\\|+=_-]/
+// Extract the first balanced JSON object. String-literal aware: braces and
+// escaped quotes inside "..." must not move the depth counter, or a model that
+// returns {"code": "if (x) { ... }"} would truncate mid-string.
 const firstJsonObject = (s) => {
   const start = s.indexOf('{')
   if (start === -1) return null
-  let depth = 0
+  let depth = 0, inString = false, escaped = false
   for (let i = start; i < s.length; i++) {
-    if (s[i] === '{') depth++
-    else if (s[i] === '}' && --depth === 0) return s.slice(start, i + 1)
+    const c = s[i]
+    if (escaped) { escaped = false; continue }
+    if (c === '\\') { escaped = true; continue }
+    if (c === '"') { inString = !inString; continue }
+    if (inString) continue
+    if (c === '{') depth++
+    else if (c === '}' && --depth === 0) return s.slice(start, i + 1)
   }
   return null
 }
@@ -223,8 +231,9 @@ let leaderboard
 try { leaderboard = await readJson(LEADERBOARD_PATH) }
 catch { leaderboard = { _description: 'Model Arena standings — updated by scripts/model-arena/run.mjs. Directional (n=1/task/round), not statistics.', rounds: 0, updated: null, models: {} } }
 
-leaderboard.rounds += 1
+leaderboard.rounds = (leaderboard.rounds || 0) + 1
 leaderboard.updated = date
+leaderboard.models ||= {}
 for (const m of activeModels) {
   const mine = results.filter((r) => r.model === m.name && r.pass !== null)
   const passes = mine.filter((r) => r.pass).length
@@ -234,6 +243,7 @@ for (const m of activeModels) {
   rec.scored += mine.length
   rec.passes += passes
   rec.passRate = rec.scored ? +(rec.passes / rec.scored).toFixed(3) : 0
+  rec.byAxis ||= {}
   for (const r of mine) {
     const ax = (rec.byAxis[r.axis] ||= { scored: 0, passes: 0 })
     ax.scored += 1; ax.passes += r.pass ? 1 : 0

--- a/scripts/model-arena/run.mjs
+++ b/scripts/model-arena/run.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+// Model Arena runner — dispatch evolving tasks to top frontier models via a
+// gateway (OpenRouter), verify mechanically, write a receipt, update the
+// leaderboard, and run the learning loop (saturation → rotate/harden).
+//
+// Why a gateway: the Claude Code Agent/Workflow harness can only spawn Claude
+// models (fable/opus/sonnet/haiku). Testing GPT-5 / Gemini / Grok / DeepSeek /
+// Qwen / Kimi / Mistral head-to-head requires an external route. OpenRouter is
+// the sanctioned one (OPENROUTER_API_KEY + OPENROUTER_BASE_URL, per CLAUDE.md).
+//
+// Modes:
+//   node run.mjs                 dispatch live via OpenRouter (needs key)
+//   node run.mjs --simulate      run the FULL pipeline with canned responses (no network) — for CI/verification
+//   node run.mjs --plan          emit the round plan only, no dispatch (also the auto-fallback when no key)
+//   node run.mjs --check         validate roster + tasks structure and exit
+//   flags: --tasks N (round size, default 4) · --week N (rotation seed, default ISO week) · --date YYYY-MM-DD
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..', '..')
+const ROSTER_PATH = join(__dirname, 'roster.json')
+const TASKS_PATH = join(__dirname, 'tasks.json')
+const LEADERBOARD_PATH = join(ROOT, 'data', 'model-arena', 'leaderboard.json')
+const RUNS_DIR = join(ROOT, 'data', 'model-arena', 'runs')
+
+const argv = process.argv.slice(2)
+const flag = (name) => argv.includes(`--${name}`)
+const opt = (name, def) => {
+  const i = argv.indexOf(`--${name}`)
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : def
+}
+
+const MODE = flag('simulate') ? 'simulate' : flag('check') ? 'check' : flag('plan') ? 'plan' : 'live'
+const ROUND_SIZE = parseInt(opt('tasks', '4'), 10)
+
+function isoWeek(d = new Date()) {
+  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))
+  const day = date.getUTCDay() || 7
+  date.setUTCDate(date.getUTCDate() + 4 - day)
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1))
+  return Math.ceil(((date - yearStart) / 86400000 + 1) / 7)
+}
+
+const readJson = async (p) => JSON.parse(await readFile(p, 'utf8'))
+
+// ── Mechanical verifiers ──────────────────────────────────────────────────
+// Each returns { pass: boolean, note: string }. `judge` tasks are not scored
+// here — they return pass:null so the workflow layer routes them to the judge.
+const PUNCT_RE = /[.,!?;:'"`~@#$%^&*()\[\]{}<>/\\|+=_-]/
+const firstJsonObject = (s) => {
+  const start = s.indexOf('{')
+  if (start === -1) return null
+  let depth = 0
+  for (let i = start; i < s.length; i++) {
+    if (s[i] === '{') depth++
+    else if (s[i] === '}' && --depth === 0) return s.slice(start, i + 1)
+  }
+  return null
+}
+const allStringsLowercase = (v) => {
+  if (typeof v === 'string') return v === v.toLowerCase()
+  if (Array.isArray(v)) return v.every(allStringsLowercase)
+  if (v && typeof v === 'object') return Object.values(v).every(allStringsLowercase)
+  return true
+}
+
+function verify(task, textRaw) {
+  const text = (textRaw ?? '').trim()
+  const v = task.verifier
+  if (!text) return { pass: false, note: 'empty response' }
+  switch (v.type) {
+    case 'numeric': {
+      const nums = text.match(/-?\d+/g)
+      if (!nums) return { pass: false, note: 'no number in reply' }
+      const last = parseInt(nums[nums.length - 1], 10)
+      return { pass: last === v.expected, note: `final number=${last} expected=${v.expected}` }
+    }
+    case 'exact': {
+      const norm = (s) => (v.case_insensitive ? s.toLowerCase() : s).replace(/\s+/g, ' ').trim()
+      return { pass: norm(text) === norm(v.expected), note: `exact match` }
+    }
+    case 'contains': {
+      const hay = v.case_insensitive ? text.toLowerCase() : text
+      const needle = v.case_insensitive ? v.expected.toLowerCase() : v.expected
+      return { pass: hay.includes(needle), note: `contains "${v.expected}"` }
+    }
+    case 'not_contains': {
+      const hay = text.toLowerCase()
+      const hit = (v.banned || []).find((b) => hay.includes(b.toLowerCase()))
+      return { pass: !hit, note: hit ? `banned term "${hit}" present` : 'no banned terms' }
+    }
+    case 'regex':
+      return { pass: new RegExp(v.pattern, v.flags || '').test(text), note: `regex ${v.pattern}` }
+    case 'word_count': {
+      const words = text.split(/\s+/).filter(Boolean)
+      const okCount = words.length === v.count
+      const okLower = !v.lowercase || words.every((w) => w === w.toLowerCase())
+      const okPunct = !v.no_punct || !PUNCT_RE.test(text)
+      return { pass: okCount && okLower && okPunct, note: `words=${words.length}/${v.count} lower=${okLower} punct-clean=${okPunct}` }
+    }
+    case 'json_schema': {
+      const raw = firstJsonObject(text)
+      if (!raw) return { pass: false, note: 'no JSON object found' }
+      let obj
+      try { obj = JSON.parse(raw) } catch { return { pass: false, note: 'JSON parse failed' } }
+      const c = v.constraints || {}
+      const hasKeys = (v.required || []).every((k) => k in obj)
+      const okTags = c.tags_length == null || (Array.isArray(obj.tags) && obj.tags.length === c.tags_length)
+      const okLower = !c.all_strings_lowercase || allStringsLowercase(obj)
+      const okProse = !c.no_extra_prose || (text.startsWith('{') && text.endsWith('}'))
+      return { pass: hasKeys && okTags && okLower && okProse, note: `keys=${hasKeys} tags=${okTags} lower=${okLower} clean=${okProse}` }
+    }
+    case 'judge':
+      return { pass: null, note: 'needs cross-family judge' }
+    default:
+      return { pass: false, note: `unknown verifier ${v.type}` }
+  }
+}
+
+// ── Simulated responses (exercise pass AND fail paths, no network) ─────────
+function cannedResponse(task, correct) {
+  const v = task.verifier
+  if (!correct) {
+    if (v.type === 'json_schema') return '{"Name": "X", "tags": ["a", "b"]}'
+    if (v.type === 'word_count') return 'one two three four five six'
+    if (v.type === 'numeric') return String((v.expected ?? 0) + 1)
+    if (v.type === 'judge') return 'Our seamless platform unlocks synergies.'
+    return 'incorrect placeholder answer'
+  }
+  switch (v.type) {
+    case 'numeric': return String(v.expected)
+    case 'contains': return v.expected
+    case 'exact': return v.expected
+    case 'word_count': return 'one two three four five'.split(' ').slice(0, v.count).join(' ')
+    case 'json_schema': return '{"name": "starlight", "tags": ["telemetry", "receipts", "arena"]}'
+    case 'not_contains': return 'a clean compliant answer'
+    case 'judge': return 'It removes hype and states the concrete mechanism plainly.'
+    default: return 'ok'
+  }
+}
+
+// ── Gateway dispatch (OpenRouter) ──────────────────────────────────────────
+async function dispatchOpenRouter(slug, prompt, key, base) {
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), 60000)
+  try {
+    const res = await fetch(`${base.replace(/\/$/, '')}/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
+      body: JSON.stringify({ model: slug, messages: [{ role: 'user', content: prompt }], temperature: 0, max_tokens: 600 }),
+      signal: ctrl.signal,
+    })
+    if (!res.ok) return { error: `HTTP ${res.status}`, text: null }
+    const data = await res.json()
+    return { text: data?.choices?.[0]?.message?.content ?? '', error: null }
+  } catch (e) {
+    return { error: e.name === 'AbortError' ? 'timeout' : e.message, text: null }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+const roster = await readJson(ROSTER_PATH)
+const taskBank = await readJson(TASKS_PATH)
+const activeModels = roster.models.filter((m) => m.arena_active && m.openrouter_slug)
+const activeTasks = taskBank.tasks.filter((t) => t.state === 'active')
+
+if (MODE === 'check') {
+  const errs = []
+  if (activeModels.length < 2) errs.push(`only ${activeModels.length} arena-active models with slugs`)
+  if (activeTasks.length < 1) errs.push('no active tasks')
+  for (const t of taskBank.tasks) if (!t.verifier?.type) errs.push(`task ${t.id} missing verifier.type`)
+  console.log(JSON.stringify({ mode: 'check', activeModels: activeModels.length, activeTasks: activeTasks.length, errors: errs }, null, 2))
+  process.exit(errs.length ? 1 : 0)
+}
+
+// Rotate: pick ROUND_SIZE active tasks, seeded by week, preferring non-saturated.
+const week = parseInt(opt('week', String(isoWeek())), 10)
+const rotated = [...activeTasks].sort((a, b) => a.id.localeCompare(b.id))
+const offset = week % Math.max(rotated.length, 1)
+const roundTasks = [...rotated.slice(offset), ...rotated.slice(0, offset)].slice(0, ROUND_SIZE)
+
+const date = opt('date', new Date().toISOString().slice(0, 10))
+const key = process.env.OPENROUTER_API_KEY
+const base = process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1'
+const effectiveMode = MODE === 'live' && !key ? 'plan' : MODE
+
+const plan = {
+  date, week, mode: effectiveMode,
+  models: activeModels.map((m) => m.name),
+  tasks: roundTasks.map((t) => ({ id: t.id, axis: t.axis, verifier: t.verifier.type })),
+  judgeNeeded: roundTasks.some((t) => t.verifier.type === 'judge'),
+}
+
+if (effectiveMode === 'plan') {
+  const reason = MODE === 'live' ? 'no OPENROUTER_API_KEY — plan only (degraded)' : 'plan mode'
+  console.log(JSON.stringify({ ...plan, degraded: MODE === 'live', reason }, null, 2))
+  process.exit(0)
+}
+
+// Dispatch every round task to every active model.
+const results = []
+for (const task of roundTasks) {
+  for (const m of activeModels) {
+    let text, error = null
+    if (effectiveMode === 'simulate') {
+      text = cannedResponse(task, activeModels.indexOf(m) % 2 === 0) // even models "pass"
+    } else {
+      const r = await dispatchOpenRouter(m.openrouter_slug, task.prompt, key, base)
+      text = r.text; error = r.error
+    }
+    const scored = error ? { pass: false, note: `dispatch error: ${error}` } : verify(task, text)
+    results.push({ taskId: task.id, axis: task.axis, model: m.name, org: m.org, pass: scored.pass, note: scored.note, error, chars: (text || '').length })
+  }
+}
+
+// ── Leaderboard update ─────────────────────────────────────────────────────
+let leaderboard
+try { leaderboard = await readJson(LEADERBOARD_PATH) }
+catch { leaderboard = { _description: 'Model Arena standings — updated by scripts/model-arena/run.mjs. Directional (n=1/task/round), not statistics.', rounds: 0, updated: null, models: {} } }
+
+leaderboard.rounds += 1
+leaderboard.updated = date
+for (const m of activeModels) {
+  const mine = results.filter((r) => r.model === m.name && r.pass !== null)
+  const passes = mine.filter((r) => r.pass).length
+  const rec = leaderboard.models[m.name] || { org: m.org, rounds: 0, scored: 0, passes: 0, passRate: 0, byAxis: {} }
+  rec.org = m.org
+  rec.rounds += 1
+  rec.scored += mine.length
+  rec.passes += passes
+  rec.passRate = rec.scored ? +(rec.passes / rec.scored).toFixed(3) : 0
+  for (const r of mine) {
+    const ax = (rec.byAxis[r.axis] ||= { scored: 0, passes: 0 })
+    ax.scored += 1; ax.passes += r.pass ? 1 : 0
+  }
+  leaderboard.models[m.name] = rec
+}
+
+// ── Learning loop: per-task saturation ─────────────────────────────────────
+const learnings = []
+for (const task of roundTasks) {
+  const scored = results.filter((r) => r.taskId === task.id && r.pass !== null)
+  if (!scored.length) continue
+  const passRate = +(scored.filter((r) => r.pass).length / scored.length).toFixed(3)
+  const bankTask = taskBank.tasks.find((t) => t.id === task.id)
+  bankTask.history.push({ date, passRate })
+  const recent = bankTask.history.slice(-taskBank.saturation_rounds)
+  if (recent.length >= taskBank.saturation_rounds && recent.every((h) => h.passRate >= taskBank.saturation_threshold)) {
+    bankTask.state = 'saturated'
+    learnings.push(`Task "${task.id}" (${task.axis}) SATURATED — field passes at ≥${taskBank.saturation_threshold} across ${taskBank.saturation_rounds} rounds. Rotate out; harden this axis with a tougher task.`)
+  }
+}
+taskBank._updated = date
+await writeFile(TASKS_PATH, JSON.stringify(taskBank, null, 2) + '\n')
+
+// ── Receipt (durable output) ───────────────────────────────────────────────
+await mkdir(RUNS_DIR, { recursive: true })
+const winner = Object.entries(leaderboard.models)
+  .filter(([, r]) => r.rounds > 0)
+  .sort(([, a], [, b]) => b.passRate - a.passRate)[0]
+const receipt = {
+  date, week, mode: effectiveMode,
+  models: activeModels.map((m) => ({ name: m.name, org: m.org, slug: m.openrouter_slug })),
+  tasks: roundTasks.map((t) => ({ id: t.id, axis: t.axis, verifier: t.verifier.type, prompt: t.prompt })),
+  results,
+  roundPassRate: leaderboard.models,
+  learnings,
+  leaderTopByPassRate: winner ? winner[0] : null,
+  caveats: [
+    'n=1 per (task,model) per round — directional signal, not statistics.',
+    'Mechanical verifiers score objective tasks; judge tasks are scored cross-family in the workflow layer.',
+    'openrouter_slug values must be verified against openrouter.ai/models; a bad slug is recorded as a dispatch error, not a fail of the model.',
+    'This measures model-via-OpenRouter (temperature 0), not model-in-Claude-Code-harness. The workflow keeps a separate in-harness Claude cross-check.',
+  ],
+}
+const receiptPath = join(RUNS_DIR, `${date}.json`)
+await writeFile(receiptPath, JSON.stringify(receipt, null, 2) + '\n')
+await mkdir(dirname(LEADERBOARD_PATH), { recursive: true })
+await writeFile(LEADERBOARD_PATH, JSON.stringify(leaderboard, null, 2) + '\n')
+
+console.log(JSON.stringify({
+  ok: true, mode: effectiveMode, date,
+  modelsRun: activeModels.length, tasksRun: roundTasks.length,
+  scored: results.filter((r) => r.pass !== null).length,
+  judgeNeeded: plan.judgeNeeded,
+  leader: receipt.leaderTopByPassRate,
+  learnings,
+  receipt: `data/model-arena/runs/${date}.json`,
+  leaderboard: 'data/model-arena/leaderboard.json',
+}, null, 2))

--- a/scripts/model-arena/run.mjs
+++ b/scripts/model-arena/run.mjs
@@ -106,13 +106,16 @@ function verify(task, textRaw) {
   if (!text) return { pass: false, note: 'empty response' }
   switch (v.type) {
     case 'numeric': {
-      const nums = text.match(/-?\d+/g)
-      if (!nums) return { pass: false, note: 'no number in reply' }
-      const last = parseInt(nums[nums.length - 1], 10)
-      return { pass: last === v.expected, note: `final number=${last} expected=${v.expected}` }
+      // Tasks say "reply with ONLY the number" — enforce a bare integer (a lone
+      // trailing period is tolerated). "the answer is 420" must FAIL, not pass on
+      // a trailing-int extraction, or mechanical verification inflates pass rates.
+      const stripped = text.replace(/[.\s]+$/, '')
+      if (!/^-?\d+$/.test(stripped)) return { pass: false, note: `not a bare integer: "${text.slice(0, 40)}"` }
+      return { pass: parseInt(stripped, 10) === v.expected, note: `reply=${stripped} expected=${v.expected}` }
     }
     case 'exact': {
-      const norm = (s) => (v.case_insensitive ? s.toLowerCase() : s).replace(/\s+/g, ' ').trim()
+      // Collapse internal whitespace, drop a trailing period/space, then compare.
+      const norm = (s) => (v.case_insensitive ? s.toLowerCase() : s).replace(/\s+/g, ' ').replace(/[.\s]+$/, '').trim()
       return { pass: norm(text) === norm(v.expected), note: `exact match` }
     }
     case 'contains': {
@@ -167,7 +170,7 @@ function cannedResponse(task, correct) {
     case 'numeric': return String(v.expected)
     case 'contains': return v.expected
     case 'exact': return v.expected
-    case 'word_count': return 'one two three four five'.split(' ').slice(0, v.count).join(' ')
+    case 'word_count': return Array.from({ length: v.count }, () => 'word').join(' ')
     case 'json_schema': return '{"name": "starlight", "tags": ["telemetry", "receipts", "arena"]}'
     case 'not_contains': return 'a clean compliant answer'
     case 'judge': return 'It removes hype and states the concrete mechanism plainly.'
@@ -253,7 +256,7 @@ if (MODE === 'check') {
   process.exit(errs.length ? 1 : 0)
 }
 
-// Rotate: pick ROUND_SIZE active tasks, seeded by week, preferring non-saturated.
+// Rotate: pick ROUND_SIZE tasks from the active set (saturated already excluded), seeded by week.
 const week = parseInt(opt('week', String(isoWeek())), 10)
 const rotated = [...activeTasks].sort((a, b) => a.id.localeCompare(b.id))
 const offset = week % Math.max(rotated.length, 1)
@@ -291,7 +294,9 @@ const dispatched = await pool(jobs, async ({ task, m }, idx) => {
     text = r.text; error = r.error; latencyMs = r.latencyMs; usage = r.usage
   }
   const scored = error ? { pass: false, note: `dispatch error: ${error}` } : verify(task, text)
-  return { taskId: task.id, axis: task.axis, model: m.name, org: m.org, pass: scored.pass, note: scored.note, error, chars: (text || '').length, latencyMs, usage }
+  // Store a truncated output so judge tasks are scorable in the workflow layer
+  // and every verdict is auditable against the raw text.
+  return { taskId: task.id, axis: task.axis, model: m.name, org: m.org, pass: scored.pass, note: scored.note, error, chars: (text || '').length, text: (text || '').slice(0, 1000), latencyMs, usage }
 }, CONCURRENCY)
 const results = dispatched
 

--- a/scripts/model-arena/run.mjs
+++ b/scripts/model-arena/run.mjs
@@ -1,23 +1,35 @@
 #!/usr/bin/env node
 // Model Arena runner — dispatch evolving tasks to top frontier models via a
-// gateway (OpenRouter), verify mechanically, write a receipt, update the
-// leaderboard, and run the learning loop (saturation → rotate/harden).
+// gateway (OpenRouter), verify mechanically, rate with pairwise Elo, capture
+// cost/latency/tokens, write a receipt, update the leaderboard, and run the
+// learning loop (saturation → rotate/harden).
 //
 // Why a gateway: the Claude Code Agent/Workflow harness can only spawn Claude
 // models (fable/opus/sonnet/haiku). Testing GPT-5 / Gemini / Grok / DeepSeek /
 // Qwen / Kimi / Mistral head-to-head requires an external route. OpenRouter is
 // the sanctioned one (OPENROUTER_API_KEY + OPENROUTER_BASE_URL, per CLAUDE.md).
 //
+// Method (premium, matches how LMArena/Chatbot-Arena rate models):
+//   - Objective tasks self-verify mechanically (no LLM judge can launder a
+//     constraint violation). Judge tasks defer to a cross-family blind judge in
+//     the workflow layer.
+//   - Per task, every ordered pair of models yields a win/loss/tie, which feeds
+//     a persistent Elo rating — a far better signal than raw pass-rate when the
+//     field is large and capability is saturated.
+//   - Every dispatch records latency + tokens (+ cost when the gateway returns
+//     it), so routing can optimize intelligence-per-dollar, not just accuracy.
+//
 // Modes:
 //   node run.mjs                 dispatch live via OpenRouter (needs key)
-//   node run.mjs --simulate      run the FULL pipeline with canned responses (no network) — for CI/verification
-//   node run.mjs --plan          emit the round plan only, no dispatch (also the auto-fallback when no key)
+//   node run.mjs --simulate      full pipeline with canned responses (no network) — for CI/verification
+//   node run.mjs --plan          print the round plan only, no dispatch (also the auto-fallback when no key)
 //   node run.mjs --check         validate roster + tasks structure and exit
-//   flags: --tasks N (round size, default 4) · --week N (rotation seed, default ISO week) · --date YYYY-MM-DD
+//   flags: --tasks N (round size, default 4) · --week N (rotation seed) · --date YYYY-MM-DD · --concurrency N (default 6)
 
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { setTimeout as sleep } from 'node:timers/promises'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..', '..')
@@ -25,6 +37,9 @@ const ROSTER_PATH = join(__dirname, 'roster.json')
 const TASKS_PATH = join(__dirname, 'tasks.json')
 const LEADERBOARD_PATH = join(ROOT, 'data', 'model-arena', 'leaderboard.json')
 const RUNS_DIR = join(ROOT, 'data', 'model-arena', 'runs')
+
+const ELO_START = 1000
+const ELO_K = 24
 
 const argv = process.argv.slice(2)
 const flag = (name) => argv.includes(`--${name}`)
@@ -35,6 +50,7 @@ const opt = (name, def) => {
 
 const MODE = flag('simulate') ? 'simulate' : flag('check') ? 'check' : flag('plan') ? 'plan' : 'live'
 const ROUND_SIZE = parseInt(opt('tasks', '4'), 10)
+const CONCURRENCY = Math.max(1, parseInt(opt('concurrency', '6'), 10))
 
 function isoWeek(d = new Date()) {
   const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))
@@ -46,13 +62,22 @@ function isoWeek(d = new Date()) {
 
 const readJson = async (p) => JSON.parse(await readFile(p, 'utf8'))
 
+// ── Bounded-concurrency pool (zero-dep; keeps the runner portable) ─────────
+async function pool(items, worker, concurrency) {
+  const results = new Array(items.length)
+  let cursor = 0
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (cursor < items.length) {
+      const idx = cursor++
+      results[idx] = await worker(items[idx], idx)
+    }
+  })
+  await Promise.all(runners)
+  return results
+}
+
 // ── Mechanical verifiers ──────────────────────────────────────────────────
-// Each returns { pass: boolean, note: string }. `judge` tasks are not scored
-// here — they return pass:null so the workflow layer routes them to the judge.
 const PUNCT_RE = /[.,!?;:'"`~@#$%^&*()\[\]{}<>\/\\|+=_-]/
-// Extract the first balanced JSON object. String-literal aware: braces and
-// escaped quotes inside "..." must not move the depth counter, or a model that
-// returns {"code": "if (x) { ... }"} would truncate mid-string.
 const firstJsonObject = (s) => {
   const start = s.indexOf('{')
   if (start === -1) return null
@@ -150,24 +175,66 @@ function cannedResponse(task, correct) {
   }
 }
 
-// ── Gateway dispatch (OpenRouter) ──────────────────────────────────────────
+// ── Gateway dispatch (OpenRouter) with retry + telemetry ───────────────────
 async function dispatchOpenRouter(slug, prompt, key, base) {
+  const started = Date.now()
   const ctrl = new AbortController()
   const timer = setTimeout(() => ctrl.abort(), 60000)
   try {
     const res = await fetch(`${base.replace(/\/$/, '')}/chat/completions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
-      body: JSON.stringify({ model: slug, messages: [{ role: 'user', content: prompt }], temperature: 0, max_tokens: 600 }),
+      body: JSON.stringify({
+        model: slug,
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0,
+        max_tokens: 600,
+        usage: { include: true }, // ask OpenRouter to attach cost + token usage
+      }),
       signal: ctrl.signal,
     })
-    if (!res.ok) return { error: `HTTP ${res.status}`, text: null }
+    const latencyMs = Date.now() - started
+    if (!res.ok) return { error: `HTTP ${res.status}`, text: null, latencyMs, usage: null }
     const data = await res.json()
-    return { text: data?.choices?.[0]?.message?.content ?? '', error: null }
+    const u = data?.usage || {}
+    return {
+      text: data?.choices?.[0]?.message?.content ?? '',
+      error: null,
+      latencyMs,
+      usage: { promptTokens: u.prompt_tokens ?? null, completionTokens: u.completion_tokens ?? null, costUsd: u.cost ?? null },
+    }
   } catch (e) {
-    return { error: e.name === 'AbortError' ? 'timeout' : e.message, text: null }
+    return { error: e.name === 'AbortError' ? 'timeout' : e.message, text: null, latencyMs: Date.now() - started, usage: null }
   } finally {
     clearTimeout(timer)
+  }
+}
+
+const RETRYABLE = /timeout|HTTP 5\d\d|HTTP 429/
+async function dispatchWithRetry(slug, prompt, key, base, tries = 3) {
+  let last
+  for (let attempt = 0; attempt < tries; attempt++) {
+    last = await dispatchOpenRouter(slug, prompt, key, base)
+    if (!last.error || !RETRYABLE.test(last.error)) return last
+    if (attempt < tries - 1) await sleep(500 * 2 ** attempt) // 0.5s, 1s backoff
+  }
+  return last
+}
+
+// ── Elo update (pairwise, per task) ────────────────────────────────────────
+const expected = (ra, rb) => 1 / (1 + 10 ** ((rb - ra) / 400))
+function updateEloForTask(ratings, scored) {
+  // scored: [{model, pass}] with pass ∈ {true,false} (judge/null already excluded)
+  for (let i = 0; i < scored.length; i++) {
+    for (let j = i + 1; j < scored.length; j++) {
+      const a = scored[i], b = scored[j]
+      const sa = a.pass === b.pass ? 0.5 : a.pass ? 1 : 0
+      const ra = ratings[a.model] ?? ELO_START
+      const rb = ratings[b.model] ?? ELO_START
+      const ea = expected(ra, rb)
+      ratings[a.model] = ra + ELO_K * (sa - ea)
+      ratings[b.model] = rb + ELO_K * ((1 - sa) - (1 - ea))
+    }
   }
 }
 
@@ -198,7 +265,7 @@ const base = process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1'
 const effectiveMode = MODE === 'live' && !key ? 'plan' : MODE
 
 const plan = {
-  date, week, mode: effectiveMode,
+  date, week, mode: effectiveMode, concurrency: CONCURRENCY,
   models: activeModels.map((m) => m.name),
   tasks: roundTasks.map((t) => ({ id: t.id, axis: t.axis, verifier: t.verifier.type })),
   judgeNeeded: roundTasks.some((t) => t.verifier.type === 'judge'),
@@ -210,39 +277,58 @@ if (effectiveMode === 'plan') {
   process.exit(0)
 }
 
-// Dispatch every round task to every active model.
-const results = []
-for (const task of roundTasks) {
-  for (const m of activeModels) {
-    let text, error = null
-    if (effectiveMode === 'simulate') {
-      text = cannedResponse(task, activeModels.indexOf(m) % 2 === 0) // even models "pass"
-    } else {
-      const r = await dispatchOpenRouter(m.openrouter_slug, task.prompt, key, base)
-      text = r.text; error = r.error
-    }
-    const scored = error ? { pass: false, note: `dispatch error: ${error}` } : verify(task, text)
-    results.push({ taskId: task.id, axis: task.axis, model: m.name, org: m.org, pass: scored.pass, note: scored.note, error, chars: (text || '').length })
+// Dispatch every (task, model) pair with bounded concurrency.
+const jobs = []
+for (const task of roundTasks) for (const m of activeModels) jobs.push({ task, m })
+const dispatched = await pool(jobs, async ({ task, m }, idx) => {
+  let text, error = null, latencyMs = null, usage = null
+  if (effectiveMode === 'simulate') {
+    text = cannedResponse(task, activeModels.indexOf(m) % 2 === 0) // even models "pass"
+    latencyMs = 200 + activeModels.indexOf(m) * 25
+    usage = { promptTokens: 40, completionTokens: 20, costUsd: 0 }
+  } else {
+    const r = await dispatchWithRetry(m.openrouter_slug, task.prompt, key, base)
+    text = r.text; error = r.error; latencyMs = r.latencyMs; usage = r.usage
   }
-}
+  const scored = error ? { pass: false, note: `dispatch error: ${error}` } : verify(task, text)
+  return { taskId: task.id, axis: task.axis, model: m.name, org: m.org, pass: scored.pass, note: scored.note, error, chars: (text || '').length, latencyMs, usage }
+}, CONCURRENCY)
+const results = dispatched
 
-// ── Leaderboard update ─────────────────────────────────────────────────────
+// ── Leaderboard update (pass-rate + Elo + cost/latency telemetry) ──────────
 let leaderboard
 try { leaderboard = await readJson(LEADERBOARD_PATH) }
-catch { leaderboard = { _description: 'Model Arena standings — updated by scripts/model-arena/run.mjs. Directional (n=1/task/round), not statistics.', rounds: 0, updated: null, models: {} } }
+catch { leaderboard = { _description: 'Model Arena standings — pass-rate + pairwise Elo + cost/latency, updated by scripts/model-arena/run.mjs. Directional (small-n), not statistics.', rounds: 0, updated: null, models: {} } }
 
 leaderboard.rounds = (leaderboard.rounds || 0) + 1
 leaderboard.updated = date
 leaderboard.models ||= {}
+
+// Elo: seed ratings from prior leaderboard, update pairwise per task, persist.
+const ratings = {}
+for (const m of activeModels) ratings[m.name] = leaderboard.models[m.name]?.elo ?? ELO_START
+for (const task of roundTasks) {
+  const scored = results.filter((r) => r.taskId === task.id && r.pass !== null)
+  if (scored.length >= 2) updateEloForTask(ratings, scored)
+}
+
 for (const m of activeModels) {
   const mine = results.filter((r) => r.model === m.name && r.pass !== null)
   const passes = mine.filter((r) => r.pass).length
-  const rec = leaderboard.models[m.name] || { org: m.org, rounds: 0, scored: 0, passes: 0, passRate: 0, byAxis: {} }
+  const all = results.filter((r) => r.model === m.name)
+  const lat = all.map((r) => r.latencyMs).filter((x) => x != null)
+  const tokens = all.reduce((s, r) => s + (r.usage?.completionTokens || 0) + (r.usage?.promptTokens || 0), 0)
+  const cost = all.reduce((s, r) => s + (r.usage?.costUsd || 0), 0)
+  const rec = leaderboard.models[m.name] || { org: m.org, elo: ELO_START, rounds: 0, scored: 0, passes: 0, passRate: 0, totalTokens: 0, totalCostUsd: 0, byAxis: {} }
   rec.org = m.org
+  rec.elo = Math.round(ratings[m.name])
   rec.rounds += 1
   rec.scored += mine.length
   rec.passes += passes
   rec.passRate = rec.scored ? +(rec.passes / rec.scored).toFixed(3) : 0
+  rec.totalTokens = (rec.totalTokens || 0) + tokens
+  rec.totalCostUsd = +((rec.totalCostUsd || 0) + cost).toFixed(4)
+  if (lat.length) rec.lastAvgLatencyMs = Math.round(lat.reduce((a, b) => a + b, 0) / lat.length)
   rec.byAxis ||= {}
   for (const r of mine) {
     const ax = (rec.byAxis[r.axis] ||= { scored: 0, passes: 0 })
@@ -270,21 +356,23 @@ await writeFile(TASKS_PATH, JSON.stringify(taskBank, null, 2) + '\n')
 
 // ── Receipt (durable output) ───────────────────────────────────────────────
 await mkdir(RUNS_DIR, { recursive: true })
-const winner = Object.entries(leaderboard.models)
+const rankedByElo = Object.entries(leaderboard.models)
   .filter(([, r]) => r.rounds > 0)
-  .sort(([, a], [, b]) => b.passRate - a.passRate)[0]
+  .sort(([, a], [, b]) => (b.elo ?? 0) - (a.elo ?? 0))
 const receipt = {
-  date, week, mode: effectiveMode,
+  date, week, mode: effectiveMode, concurrency: CONCURRENCY,
   models: activeModels.map((m) => ({ name: m.name, org: m.org, slug: m.openrouter_slug })),
   tasks: roundTasks.map((t) => ({ id: t.id, axis: t.axis, verifier: t.verifier.type, prompt: t.prompt })),
   results,
-  roundPassRate: leaderboard.models,
+  standings: rankedByElo.map(([name, r]) => ({ name, elo: r.elo, passRate: r.passRate, totalTokens: r.totalTokens, totalCostUsd: r.totalCostUsd, lastAvgLatencyMs: r.lastAvgLatencyMs })),
   learnings,
-  leaderTopByPassRate: winner ? winner[0] : null,
+  leaderByElo: rankedByElo[0]?.[0] ?? null,
   caveats: [
     'n=1 per (task,model) per round — directional signal, not statistics.',
-    'Mechanical verifiers score objective tasks; judge tasks are scored cross-family in the workflow layer.',
+    'Elo is seeded from prior rounds and updated pairwise per task; early ratings are volatile until several rounds accumulate.',
+    'Mechanical verifiers score objective tasks; judge tasks are scored cross-family in the workflow layer and merged into the receipt there.',
     'openrouter_slug values must be verified against openrouter.ai/models; a bad slug is recorded as a dispatch error, not a fail of the model.',
+    'Cost/token telemetry depends on the gateway returning usage; it is best-effort and 0 when absent (e.g. simulate mode).',
     'This measures model-via-OpenRouter (temperature 0), not model-in-Claude-Code-harness. The workflow keeps a separate in-harness Claude cross-check.',
   ],
 }
@@ -298,7 +386,7 @@ console.log(JSON.stringify({
   modelsRun: activeModels.length, tasksRun: roundTasks.length,
   scored: results.filter((r) => r.pass !== null).length,
   judgeNeeded: plan.judgeNeeded,
-  leader: receipt.leaderTopByPassRate,
+  leader: receipt.leaderByElo,
   learnings,
   receipt: `data/model-arena/runs/${date}.json`,
   leaderboard: 'data/model-arena/leaderboard.json',

--- a/scripts/model-arena/tasks.json
+++ b/scripts/model-arena/tasks.json
@@ -1,0 +1,120 @@
+{
+  "_description": "Evolving task bank for the Model Arena. Tasks are meaningful (real capability axes, not trivia), mostly self-verifying (mechanical checks over LLM judgment), and EVOLVING: when the whole field passes a task across ≥2 rounds it is marked `saturated` and rotated out, and the runner emits a 'harden this axis' suggestion. New tasks enter with state `active`.",
+  "_verifier_contract": "The runner executes `verifier` mechanically against the model's final text. Types: exact | contains | not_contains | regex | word_count | json_schema | numeric | judge. `judge` tasks are scored by the cross-family blind judge in the workflow layer, not the pure script.",
+  "_learning_loop": "state: active → saturated (all-active-models pass rate ≥ 0.95 for ≥2 consecutive rounds) → retired (manual). `history` accumulates {date, passRate} per round. `version` bumps when the prompt is hardened.",
+  "_updated": "2026-07-12",
+  "saturation_threshold": 0.95,
+  "saturation_rounds": 2,
+  "tasks": [
+    {
+      "id": "reasoning-lcm-not-divisible",
+      "axis": "reasoning-no-tools",
+      "difficulty": "medium",
+      "state": "active",
+      "version": 1,
+      "prompt": "Find the smallest positive integer divisible by every integer from 1 to 7 but NOT divisible by 8. Reply with ONLY the number, nothing else.",
+      "verifier": {
+        "type": "numeric",
+        "expected": 420
+      },
+      "caveat": "Ground truth fixed by harness (LCM(1..7)=420, not divisible by 8).",
+      "history": []
+    },
+    {
+      "id": "grounding-not-stated",
+      "axis": "grounding-hallucination",
+      "difficulty": "medium",
+      "state": "active",
+      "version": 1,
+      "prompt": "Context: 'The Starlight runner dispatches tasks to models via a gateway and writes a JSON receipt per round.' Question: What retry policy does the runner use on a gateway timeout? Answer in one short sentence. If the context does not state it, say exactly: not stated.",
+      "verifier": {
+        "type": "contains",
+        "expected": "not stated",
+        "case_insensitive": true
+      },
+      "caveat": "Honest answer is 'not stated' — the context is silent on retries. Fabricating a policy fails.",
+      "history": []
+    },
+    {
+      "id": "compliance-five-words",
+      "axis": "instruction-compliance",
+      "difficulty": "easy",
+      "state": "active",
+      "version": 1,
+      "prompt": "Describe a compiler in exactly five words, all lowercase, no punctuation of any kind. Output only those five words.",
+      "verifier": {
+        "type": "word_count",
+        "count": 5,
+        "lowercase": true,
+        "no_punct": true
+      },
+      "caveat": "Pure mechanical constraint check — the axis the public arena found most discriminating.",
+      "history": []
+    },
+    {
+      "id": "constraint-json-schema",
+      "axis": "structured-output",
+      "difficulty": "medium",
+      "state": "active",
+      "version": 1,
+      "prompt": "Output ONLY a raw JSON object (no code fences, no prose) matching: {\"name\": string, \"tags\": string[]}. Rules: exactly 3 tags; every string value entirely lowercase; no preamble or trailing text.",
+      "verifier": {
+        "type": "json_schema",
+        "required": [
+          "name",
+          "tags"
+        ],
+        "constraints": {
+          "tags_length": 3,
+          "all_strings_lowercase": true,
+          "no_extra_prose": true
+        }
+      },
+      "caveat": "Parses the first JSON object in the reply; fails on capitalized values, wrong tag count, or conversational leak around it.",
+      "history": []
+    },
+    {
+      "id": "reasoning-output-prediction",
+      "axis": "code-reasoning",
+      "difficulty": "medium",
+      "state": "active",
+      "version": 1,
+      "prompt": "Given this function: `def f(n): return sum(1 for i in range(2, n) if n % i == 0)`. What does f(12) return? Reply with ONLY the integer.",
+      "verifier": {
+        "type": "numeric",
+        "expected": 4
+      },
+      "caveat": "Ground truth: divisors of 12 in range(2,12) are 2,3,4,6 → 4. Tests code tracing without a tool.",
+      "history": []
+    },
+    {
+      "id": "longcontext-planted-fact",
+      "axis": "long-context-fidelity",
+      "difficulty": "medium",
+      "state": "active",
+      "version": 1,
+      "prompt": "The following log has one line that contradicts the others. Lines: 'build ok', 'tests ok', 'deploy ok', 'lint FAILED with 3 errors', 'ship ok'. Which single line reports a failure? Reply with ONLY that exact line text.",
+      "verifier": {
+        "type": "contains",
+        "expected": "lint FAILED with 3 errors",
+        "case_insensitive": false
+      },
+      "caveat": "Needle-in-context: must return the one failing line verbatim, not summarize.",
+      "history": []
+    },
+    {
+      "id": "judgment-brand-voice",
+      "axis": "judgment-craft",
+      "difficulty": "hard",
+      "state": "active",
+      "version": 1,
+      "prompt": "Rewrite this AI-slop sentence in a direct, technical, results-first voice with zero hype words (no 'unlock', 'seamless', 'supercharge', 'delve', 'elevate'): 'Our seamless AI platform unlocks transformative synergies to supercharge your workflow.' Keep it under 25 words.",
+      "verifier": {
+        "type": "judge",
+        "rubric": "Scored blind by cross-family judge on: hype-word removal (mechanical pre-check bans the 5 words), concreteness, and whether it says something real rather than nothing. Under-25-words enforced mechanically before judging."
+      },
+      "caveat": "Half-mechanical: the 5 banned words are checked by script; taste is judged blind. Kept ≤ half the card per arena task-design rules.",
+      "history": []
+    }
+  ]
+}

--- a/scripts/model-arena/tasks.json
+++ b/scripts/model-arena/tasks.json
@@ -26,9 +26,9 @@
       "difficulty": "medium",
       "state": "active",
       "version": 1,
-      "prompt": "Context: 'The Starlight runner dispatches tasks to models via a gateway and writes a JSON receipt per round.' Question: What retry policy does the runner use on a gateway timeout? Answer in one short sentence. If the context does not state it, say exactly: not stated.",
+      "prompt": "Context: 'The Starlight runner dispatches tasks to models via a gateway and writes a JSON receipt per round.' Question: What retry policy does the runner use on a gateway timeout? If the context does not state it, reply with EXACTLY these two words and nothing else: not stated.",
       "verifier": {
-        "type": "contains",
+        "type": "exact",
         "expected": "not stated",
         "case_insensitive": true
       },
@@ -93,9 +93,9 @@
       "difficulty": "medium",
       "state": "active",
       "version": 1,
-      "prompt": "The following log has one line that contradicts the others. Lines: 'build ok', 'tests ok', 'deploy ok', 'lint FAILED with 3 errors', 'ship ok'. Which single line reports a failure? Reply with ONLY that exact line text.",
+      "prompt": "The following log has one line that contradicts the others. Lines: 'build ok', 'tests ok', 'deploy ok', 'lint FAILED with 3 errors', 'ship ok'. Which single line reports a failure? Reply with ONLY that exact line text, nothing else.",
       "verifier": {
-        "type": "contains",
+        "type": "exact",
         "expected": "lint FAILED with 3 errors",
         "case_insensitive": false
       },


### PR DESCRIPTION
## Summary

The ACOS copy of `model-arena-daily.js` was a stale, **Claude-only** duplicate. This brings it to parity with the FrankX rebuild: a self-contained OpenRouter runner (`scripts/model-arena/`) that dispatches an evolving task bank to 13 frontier models across 8 orgs, verifies mechanically, keeps a learning leaderboard, and commits a durable receipt. (The `automation-overseer` is intentionally **not** ported — it reads FrankX's scheduled-routines registry, which ACOS doesn't maintain.)

## Change Type

- [x] New feature (non-breaking change that adds functionality)
- [x] CI/Workflow change

## Frank DNA Alignment

- [x] **Serves the mission** — a real multi-model eval harness people can read, run, and extend
- [x] **Shows don't tells** — receipts + leaderboard are the output; caveats ship with every round
- [x] **Practical value** — answers "which model do I route this task to" with first-party evidence
- [x] **Direct voice** — no AI-slop in docs or receipts
- [x] **No AI slop** — n=1 caveats stated plainly, vendor claims marked as such

## Testing

- [x] Ran locally and tested the golden path — `node scripts/model-arena/run.mjs --simulate` runs the full dispatch→verify→leaderboard→learn→receipt pipeline with no network
- [x] Tested edge cases — `--check` (config validation) and `--plan` (degraded, no key) modes
- [x] Ran existing tests — `node scripts/workflow-validate.mjs` → 8/8 ok
- [x] For workflows: Tested in draft PR

## Notes

`new-model` detection degrades gracefully where no `data/model-registry.json` is present (ACOS doesn't maintain one) — it reports the file missing rather than failing the round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJjvk1Rmrrwv2tpjtBZzGh

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJjvk1Rmrrwv2tpjtBZzGh)_