### PR TITLE
feat(content): add evidence-bound content intelligence pipeline

### DIFF
--- a/.claude/commands/article-creator.md
+++ b/.claude/commands/article-creator.md
@@ -1,74 +1,53 @@
-# /create-article - Guided Article Creation
+# /article-creator — Content Intelligence Article Pipeline
 
-**ACOS Content Factory Pipeline - From idea to LIVE article**
+Create a source-grounded article and take it only as far as the operator's authority permits.
 
-## CRITICAL: This is a FULLY GUIDED workflow
+## Contract
 
-When this command is invoked, the agent MUST guide the user through ALL steps:
+Read:
 
-1. ✅ Show backlog and ask which article to create
-2. ✅ Ask about angle and length
-3. ✅ Write draft to `content/drafts/frankx/blog/`
-4. ✅ Ask about images (generate if API available)
-5. ✅ Move to `content/blog/` and set `draft: false`
-6. ✅ **ALWAYS run deploy at the end**
-7. ✅ Show the LIVE URL when complete
+1. `docs/content-intelligence.md`
+2. `skills/blog-writing/SKILL.md`
+3. `skills/seo-optimization/SKILL.md`
+4. `workflows/content/research-to-article.yaml`
 
-## Workflow
+Create working state from `templates/content/article-packet.json`.
 
-```
-╔═══════════════════════════════════════════════════════════════════╗
-║                   CONTENT FACTORY PIPELINE                         ║
-╠═══════════════════════════════════════════════════════════════════╣
-║  1. SELECT   →  2. WRITE   →  3. STAGE   →  4. DEPLOY  →  5. LIVE ║
-║  (backlog)      (drafts/)     (blog/)       (/deploy)     (URL)   ║
-╚═══════════════════════════════════════════════════════════════════╝
+Default authority is `DRAFT`. A request to write does not silently authorize repository, deployment, CMS, scheduler, or social writes.
+
+## Invocation
+
+```text
+/article-creator [topic or source]
+/article-creator --authority=DRAFT|PREVIEW|PUBLISH|DISTRIBUTE [topic or source]
 ```
 
-## Step 1: Show Backlog & Select
+Infer routine context from the active repository and connected evidence. Ask only when a missing choice changes public identity, rights, secrecy, destructive scope, or publication authority. Do not force the user through a generic backlog/angle/length questionnaire.
 
-Show articles from `data/inventories/creation-pipeline.json`
-Ask user to select or propose new idea
+## Execution
 
-## Step 2: Write Draft
+1. Resolve the task envelope: creator/property, canonical repository/CMS, audience, authority, rights, timing, and success condition.
+2. Inspect active instructions, current content model, existing related URLs, editorial state, live route, and performance evidence.
+3. Build the source and claim ledgers; capture current primary sources and a dated search/competitor snapshot when discovery matters.
+4. Pass the commission gate. Return one precise reporting assignment, `HOLD`, or `KILL` when origin, evidence, or information gain is missing.
+5. Freeze the thesis, reader consequence, strongest objection, canonical/internal-link role, offer/affiliate relationship, and media necessity.
+6. Draft in the active creator voice. Do not impose word count, keyword density, TL;DR, question headings, FAQ, link count, image count, or CTA unless the subject/repository requires it.
+7. Run independent truth/rights, commissioning/ICP, SEO/GEO, visual, and production lanes. Allow one substantive editorial rewrite.
+8. For `PREVIEW+`, create a content branch and pull request, run repository-native checks, and inspect the rendered preview on mobile and desktop.
+9. For `PUBLISH+`, release only after every gate passes and verify the canonical production URL.
+10. For `DISTRIBUTE`, create channel-native objects with content ID, UTMs, disclosure, asset renditions, approval, remote result, and final URL.
+11. Record T+0/T+7/T+28/T+90 measurement and freshness triggers.
 
-- Ask about angle (beginner/advanced/etc)
-- Ask about length (quick/medium/pillar)
-- Create draft in `content/drafts/frankx/blog/[slug].mdx`
-- Include: TL;DR, question-based H2s, FAQ section
+## Completion
 
-## Step 3: Generate Images (Optional)
+Lead with the actual article or verified preview. Then return:
 
-If Nano Banana API is available:
-- Generate header image
-- Save to `public/images/blog/[slug]/`
+- status and authority;
+- canonical property/path and content ID;
+- key sources and claims changed or removed;
+- media asset IDs and placements;
+- checks and independent verdicts;
+- remote writes and verified URLs;
+- blockers, rollback, and next measurement event.
 
-## Step 4: Stage for Publication
-
-Move from drafts to content/blog:
-```bash
-mv content/drafts/frankx/blog/[slug].mdx content/blog/[slug].mdx
-```
-
-Set `draft: false` in frontmatter
-
-## Step 5: DEPLOY (MANDATORY)
-
-**NEVER skip this step!**
-
-```bash
-# Regenerate inventory
-node scripts/generate-blog-inventory.mjs
-
-# Deploy to production
-./scripts/sync-to-production.sh "feat: Publish article - [title]"
-```
-
-## Step 6: Confirm Live
-
-Show the user:
-"Your article is now LIVE at: https://frankx.ai/blog/[slug]"
-
----
-
-*The workflow is complete when the article is LIVE on frankx.ai*
+Never synthesize a live URL, claim a deployment from a commit alone, or mark `PUBLISHED`/`DISTRIBUTED` without remote confirmation.

--- a/.claude/commands/article-creator.md
+++ b/.claude/commands/article-creator.md
@@ -1,3 +1,8 @@
+---
+name: article-creator
+description: Create a source-grounded article and advance it only to the explicitly authorized state
+---
+
 # /article-creator — Content Intelligence Article Pipeline
 
 Create a source-grounded article and take it only as far as the operator's authority permits.

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -1,155 +1,63 @@
-# /publish - Content Publishing Command
+# /publish — Evidence-Bound Publishing Orchestrator
 
-You are the **Publishing Orchestrator** - Frank's intelligent content publishing pipeline that ensures every piece of content meets the highest standards before going live.
+Publish a reviewed content packet through the active repository/CMS and verify the actual production result.
 
-## Overview
+## Contract
 
-```
-/publish [path]              → Publish specific content file
-/publish --all               → Publish all ready content
-/publish --dry-run [path]    → Preview without publishing
-/publish --skip-review [path] → Skip agent review (faster)
-/publish --force [path]      → Bypass quality gates
-```
+Read `docs/content-intelligence.md` and the target repository's instructions/content schema before action. Use the working article packet based on `templates/content/article-packet.json`.
 
-## Quality Gates
-
-Each gate must pass before publishing. Gates return: PASS, WARN, or FAIL.
-
-### Gate 1: Structure Validation
-- [ ] Valid frontmatter (title, description, date, category, tags)
-- [ ] publishedAt date is today or in the past
-- [ ] Description is 120-160 characters (SEO optimal)
-- [ ] At least 3 tags
-- [ ] Category matches allowed list
-
-### Gate 2: SEO Check
-- [ ] Title is 50-60 characters
-- [ ] Meta description is compelling and keyword-rich
-- [ ] H1 matches title (or close)
-- [ ] H2s contain target keywords
-- [ ] Internal links: minimum 3
-- [ ] External links: minimum 1 (authority sources)
-- [ ] Alt text on all images
-
-### Gate 3: Voice & Brand
-- [ ] Matches FrankX voice (technical yet accessible)
-- [ ] No AI-sounding phrases ("I cannot", "As an AI", "delve", "it's worth noting")
-- [ ] Active voice predominant
-- [ ] First person used appropriately
-- [ ] Consistent tone throughout
-
-### Gate 4: AEO (AI Engine Optimization)
-- [ ] TL;DR in first 100 words
-- [ ] FAQ section with 5+ questions
-- [ ] Clear definitions for technical terms
-- [ ] Structured data ready (Article + FAQPage)
-- [ ] datePublished and dateModified present
-
-## Execution Instructions
-
-### For `/publish [path]`:
-
-1. **Validate file exists**:
-   ```bash
-   Read the file at [path]
-   Parse frontmatter
-   ```
-
-2. **Run quality gates**:
-   ```
-   Gate 1: Check frontmatter fields
-   Gate 2: Count links, check title length
-   Gate 3: Search for AI phrases, analyze voice
-   Gate 4: Check for TL;DR and FAQ
-   ```
-
-3. **Report results**:
-   ```
-   ╔════════════════════════════════════════════════════════════════╗
-   ║                    PUBLISH REPORT                              ║
-   ╠════════════════════════════════════════════════════════════════╣
-   ║ Post: [Title]                                                  ║
-   ║ Path: [path]                                                   ║
-   ╠════════════════════════════════════════════════════════════════╣
-   ║ ✅ Structure Validation    PASS                                ║
-   ║ ✅ SEO Check               PASS (score: 92/100)                ║
-   ║ ⚠️  Voice & Brand          WARN (found "delve" - removed)      ║
-   ║ ✅ AEO Optimization        PASS                                ║
-   ╠════════════════════════════════════════════════════════════════╣
-   ║ Ready to publish? (y/n)                                        ║
-   ╚════════════════════════════════════════════════════════════════╝
-   ```
-
-4. **If approved, deploy**:
-   ```bash
-   # Copy to Vercel website repo
-   cp [path] ../FrankX.AI\ -\ Vercel\ Website/content/blog/
-
-   # Commit and push
-   git add .
-   git commit -m "publish: [title]"
-   git push origin main
-   ```
-
-5. **Log to session file**:
-   ```bash
-   # Append to AI_GLOBAL_SESSIONS.md
-   echo "## Published: [title]" >> /mnt/c/Users/Frank/docs/AI_GLOBAL_SESSIONS.md
-   echo "- Path: [path]" >> /mnt/c/Users/Frank/docs/AI_GLOBAL_SESSIONS.md
-   echo "- Date: $(date)" >> /mnt/c/Users/Frank/docs/AI_GLOBAL_SESSIONS.md
-   ```
-
-## AI Phrase Blacklist
-
-These phrases should be flagged and removed:
-
-```
-"I cannot"
-"As an AI"
-"delve"
-"it's worth noting"
-"dive into"
-"in conclusion"
-"let's explore"
-"it's important to note"
-"I'd be happy to"
-"certainly"
-"absolutely"
-"I don't have access"
-"based on my training"
+```text
+/publish [path-or-content-id]
+/publish --dry-run [path-or-content-id]
+/publish --authority=PREVIEW|PUBLISH|DISTRIBUTE [path-or-content-id]
 ```
 
-## Example Output
+There is no `--force`, `--skip-review`, direct-to-main, hard-coded copy path, or fabricated live URL path. Resolve the canonical publisher from repository evidence.
 
-```
-╔════════════════════════════════════════════════════════════════╗
-║                    PUBLISH REPORT                              ║
-╠════════════════════════════════════════════════════════════════╣
-║ Post: The 7 Pillars of Production Agent Systems                ║
-║ Path: content/blog/production-agent-patterns-7-pillars.mdx     ║
-║ Date: 2026-01-23                                               ║
-╠════════════════════════════════════════════════════════════════╣
-║                    QUALITY GATES                               ║
-╠════════════════════════════════════════════════════════════════╣
-║ ✅ Structure Validation    PASS                                ║
-║ ✅ SEO Check               PASS (score: 92/100)                ║
-║ ✅ Voice & Brand           PASS                                ║
-║ ✅ AEO Optimization        PASS                                ║
-╠════════════════════════════════════════════════════════════════╣
-║                    PUBLISH STATUS                              ║
-╠════════════════════════════════════════════════════════════════╣
-║ ✅ Committed: abc123f                                          ║
-║ ✅ Pushed to main                                              ║
-║ ✅ Vercel deployment triggered                                 ║
-║                                                                ║
-║ 🔗 Preview: https://frankx.ai/blog/production-agent-patterns   ║
-╚════════════════════════════════════════════════════════════════╝
-```
+## Preflight
 
-## Integration
+Require:
 
-Works with:
-- `/factory` - Content creation pipeline
-- `/frankx-ai-deploy` - Vercel deployment
-- Session logging at `AI_GLOBAL_SESSIONS.md`
+- stable content ID, canonical creator/property, repository/CMS path, and explicit authority;
+- frozen thesis and reader consequence;
+- source and typed claim ledgers with no unresolved central claim;
+- truth/rights, commissioning editor, SEO/GEO, and production-verifier passes;
+- governed media identities, provenance, rights, alt text, placements, and approval;
+- correct commercial relationship, affiliate disclosure/link qualification, and current destination;
+- index/canonical/sitemap/structured-data/internal-link plan;
+- rollback or supersession path.
+
+Return the exact blocker when any requirement fails.
+
+## Preview
+
+1. Create or reuse a content branch; never overwrite unrelated work.
+2. Apply the smallest coherent change according to the target content model.
+3. Run repository-native format, lint, type, content/schema, link, and production-build checks.
+4. Create a pull request with brief, source/evidence receipt, media placements, test results, risk, and rollback.
+5. Resolve the actual preview deployment and inspect mobile/desktop output:
+   - HTTP and rendered main content;
+   - title, description, author/dates, canonical, robots/snippet controls;
+   - JSON-LD matching visible content;
+   - images, alt text, crop, links, responsive behavior;
+   - analytics events and runtime/build errors.
+6. Mark `PREVIEW_LIVE` only when the pull request and preview are confirmed.
+
+## Production
+
+Proceed only with `PUBLISH` or `DISTRIBUTE` authority and passed preview/release gates.
+
+1. Merge or release through the repository/CMS native path.
+2. Resolve the production deployment and canonical URL.
+3. Verify the live page serves the intended version and critical metadata/assets/links.
+4. Capture commit/PR/deployment/live URL/time and rollback evidence.
+5. Update the existing editorial record; do not create another cockpit or canonical copy.
+6. Mark `PUBLISHED` only after production readback succeeds.
+
+## Distribution
+
+With `DISTRIBUTE` authority, stage or publish only to named verified accounts. Preserve content ID, source version, copy/media versions, UTMs, disclosure, approval, schedule, remote result ID, and final URL. A live article does not imply automatic social permission.
+
+## Report
+
+Return the live or preview URL first, then the gate verdicts, executed writes, verification, blockers, rollback, and next measurement event. Never expose credentials, signed URLs, private source material, or internal tokens.

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -1,3 +1,8 @@
+---
+name: publish
+description: Publish a reviewed content packet through the canonical publisher and verify the remote result
+---
+
 # /publish — Evidence-Bound Publishing Orchestrator
 
 Publish a reviewed content packet through the active repository/CMS and verify the actual production result.

--- a/.claude/commands/seo-check.md
+++ b/.claude/commands/seo-check.md
@@ -1,3 +1,8 @@
+---
+name: seo-check
+description: Review search and AI-discovery eligibility, integrity, usefulness, links, entities, and measurement
+---
+
 # /seo-check — Search and AI-Discovery Review
 
 Review rendered technical eligibility, source/reader value, entity consistency, link architecture, AI-discovery controls, and measured outcomes using current first-party guidance.

--- a/.claude/commands/seo-check.md
+++ b/.claude/commands/seo-check.md
@@ -1,92 +1,82 @@
-# /seo-check - Weekly SEO & Traffic Review
+# /seo-check — Search and AI-Discovery Review
 
-Quick audit of SEO health and traffic performance.
+Review rendered technical eligibility, source/reader value, entity consistency, link architecture, AI-discovery controls, and measured outcomes using current first-party guidance.
 
-## Execution Steps
+## Contract
 
-### Step 1: Check Site Indexing
-```bash
-# Check how many pages Google has indexed
-curl -s "https://www.google.com/search?q=site:frankx.ai" | grep -o "About [0-9,]* results" || echo "Check manually: site:frankx.ai"
+Read:
+
+- `docs/content-intelligence.md`
+- `skills/seo-optimization/SKILL.md`
+- target repository instructions and content schema
+
+Do not use scraped `site:` result counts, keyword-density formulas, fixed link/image counts, mandatory FAQ schema, generic SEO scores, or unrepeatable prompts to AI products as measurement.
+
+## Modes
+
+```text
+/seo-check [URL-or-content-id]
+/seo-check --site [domain]
+/seo-check --cluster [cluster-id]
+/seo-check --measurement [content-id]
 ```
 
-### Step 2: Verify Sitemap
-```bash
-# Fetch and count sitemap URLs
-curl -s https://frankx.ai/sitemap.xml | grep -c "<url>" || echo "Sitemap check failed"
-```
+## Evidence collection
 
-### Step 3: Manual Checks (Open in Browser)
+1. Resolve canonical domain, repository/project, content ID, source path, current deployment, locale, and observation window.
+2. Read connected Search Console, Bing Webmaster, analytics, link, affiliate/product, and editorial records when available. State unavailable lanes rather than inventing zeros.
+3. Capture current primary search/crawler guidance for unstable policy questions.
+4. Annotate algorithm updates, data incidents, migrations, campaigns, and seasonality.
 
-**Google Search Console:**
-- https://search.google.com/search-console/performance/search-analytics?resource_id=sc-domain:frankx.ai
+## Rendered technical checks
 
-**Plausible Analytics:**
-- https://plausible.io/frankx.ai (or your dashboard URL)
+- public HTTP 200 and meaningful server/static main content;
+- index/noindex and snippet controls;
+- canonical, redirects, sitemap membership, truthful `lastmod`;
+- title, description, headings, locale, author/profile, publication/update dates;
+- visible-content-consistent JSON-LD and validation;
+- crawlable internal links, orphan status, broken links, redirect chains, canonical conflicts;
+- standard image markup, stable URLs, alt text, representative image variants, crawlability;
+- mobile output, performance, hydration/runtime errors, analytics events.
 
-**AI Citation Check:**
-- Ask ChatGPT: "What is Agentic Creator OS?"
-- Ask Perplexity: "Who is FrankX AI?"
-- Search Google: "agentic creator os" - check AI Overview
+Robots exclusion is not a deindexing method. Do not infer indexing from a sitemap alone.
 
-### Step 4: Quick SEO Audit
+## Editorial and discovery checks
 
-Check these for each new article:
+- exact reader intent and competent-reader baseline;
+- first-party origin or research delta;
+- material claims with primary/authoritative sources, dates, and freshness;
+- information gain versus current result set;
+- coherent entities, questions, answer units, and cross-format facts;
+- topic/cluster role and cannibalization/consolidation decision;
+- proportional offer/affiliate relationship and disclosure;
+- headline and imagery accurately representing the page.
 
-| Check | How |
-|-------|-----|
-| TL;DR in first 100 words | Read article intro |
-| Question-based H2s | Scan headings |
-| FAQ section | Scroll to bottom |
-| Internal links | Check for 3+ links to other content |
-| Meta description | View page source or use browser SEO extension |
+Google requires no special AI schema or AI text file and says it ignores `llms.txt`. Track `OAI-SearchBot` and `GPTBot` independently and use product-specific crawler controls. Never promise AI inclusion.
 
-### Step 5: Content Performance Review
+## Measurement
 
-**Top Performers (what's working):**
-- Which blog posts get the most traffic?
-- Which keywords drive the most clicks?
-- What's the avg. position for target keywords?
+Separate:
 
-**Opportunities (what to improve):**
-- Pages with high impressions but low CTR (improve titles)
-- Pages ranking #4-10 (push to top 3)
-- Keywords you're NOT ranking for yet
+- Google Web impressions/clicks/queries/pages;
+- Google generative-AI impressions where the report is available;
+- Bing AI citations/grounding-query samples, which are not rank or authority;
+- analytics qualified visits, engagement, actions, and conversions;
+- AI/search/social/referral traffic, earned links, subscriptions, opportunities, affiliates, and revenue;
+- research/production/distribution/maintenance cost.
 
-## Output Template
+Use T+0, T+7, T+28, and T+90 snapshots or an evidence-appropriate longer window. Search Console and analytics measure different systems and will not match exactly.
 
-```markdown
-## SEO Check - [DATE]
+## Output
 
-### Traffic Summary (Last 7 Days)
-- Visitors:
-- Pageviews:
-- Top Page:
-- Top Referrer:
+Return:
 
-### Search Console (Last 28 Days)
-- Total Clicks:
-- Total Impressions:
-- Avg. CTR:
-- Avg. Position:
+1. decision and highest-impact finding;
+2. measurement integrity and current state;
+3. technical/index/render findings;
+4. editorial/entity/link findings;
+5. discovery, trust, and commercial evidence;
+6. explicit guidance versus inference;
+7. prioritized fixes or experiment with owner, evidence, expected effect, guardrails, and verification date.
 
-### Top Keywords
-1. [keyword] - pos [X], [N] clicks
-2. [keyword] - pos [X], [N] clicks
-3. [keyword] - pos [X], [N] clicks
-
-### AI Citations Found
-- [ ] ChatGPT mentions FrankX
-- [ ] Perplexity cites content
-- [ ] Google AI Overview includes
-
-### Action Items
-- [ ] Optimize [page] for [keyword]
-- [ ] Add FAQ to [article]
-- [ ] Internal link from [high-traffic] to [new content]
-```
-
-## Related Commands
-- `/inventory-status` - Content inventory
-- `/factory` - Content publishing
-- `/log` - Session logging
+Never attribute movement to one algorithm or content change without cohort, timing, and technical evidence.

--- a/docs/content-intelligence.md
+++ b/docs/content-intelligence.md
@@ -1,0 +1,192 @@
+# Content Intelligence Contract
+
+Version: 1.0.0  
+Verified against first-party search guidance: 2026-08-26
+
+ACOS content work is an evidence-bound editorial system, not a volume generator. Scale research contracts, publishing infrastructure, and learning loops; do not scale commodity prose.
+
+## Governing outcome
+
+Publish work with a source-visible unique contribution that serves a real reader, clears rights and technical gates, compounds the creator's authority, and produces measurable learning or commercial value.
+
+`PUBLISH NOTHING` is valid when origin, evidence, reader consequence, or authority is missing.
+
+## System shape
+
+Use a manager-workers vertical:
+
+- editor-in-chief: task envelope, commission, synthesis, conflict resolution, final status;
+- research lead: primary sources, SERP/competitor snapshot, claim candidates;
+- fact/rights reviewer: claim support, quotation, privacy, license, disclosure;
+- SEO/GEO architect: intent, entities, crawl/render, metadata, schema, links;
+- author: source-grounded draft and one substantive revision;
+- commissioning/ICP editor: origin, information gain, trust, reader transfer;
+- visual director: visual necessity and governed production brief;
+- production engineer: repository checks, preview, deployment evidence;
+- distribution/revenue lead: channel adaptation, UTM, offer/affiliate fit;
+- measurement analyst: dated snapshots, diagnosis, refresh decision.
+
+Workers append to one article packet. They cannot silently overwrite another lane or approve their own work.
+
+## Authority levels
+
+| Level | Allowed actions |
+| --- | --- |
+| `DRAFT` | Research, brief, article packet, local draft, media brief, validation |
+| `PREVIEW` | `DRAFT` plus branch, commit, pull request, preview, editorial-ledger update |
+| `PUBLISH` | `PREVIEW` plus merge/CMS release and production verification for the named property |
+| `DISTRIBUTE` | `PUBLISH` plus approved scheduling/posting to named accounts and result capture |
+
+A request to write does not imply publish. A request to publish one property does not authorize every property or social account. Use explicit operator language or checked-in standing policy.
+
+## Canonical source responsibilities
+
+Keep one owner per truth:
+
+- Git repository or repository-backed CMS: publishable source, code, schema, policy, history;
+- editorial system: briefs, decisions, status, assignment, review context;
+- document store: proofs, source files, collaborator review, handoff;
+- deployed site: rendered behavior, metadata/schema, preview/production evidence;
+- analytics: dated measurements, never editorial canon;
+- scheduler: staged/approved channel objects and remote results, never article canon.
+
+Do not create a second cockpit when one already exists. Never claim a remote write, preview, deployment, page, or post exists without connector evidence.
+
+## Source and claim control
+
+Use the closest authoritative source:
+
+1. verified first-party artifact, measured result, approved statement, or direct observation;
+2. canonical code/configuration/release/telemetry/CMS record;
+3. primary external documentation, standard, law, filing, dataset, or paper;
+4. inspectable high-quality synthesis;
+5. community discourse as a language or demand signal only.
+
+Read the full source. Search snippets establish relevance, not truth. Record publication/update time and retrieval time separately.
+
+Every material claim records:
+
+- stable claim ID and atomic public wording;
+- type: `fact`, `first_party`, `inference`, `opinion`, `forecast`, or `community_signal`;
+- source IDs and support: `direct`, `derived`, `contextual`, `contested`, or `blocked`;
+- `as_of` date, freshness/expiry trigger, and independent verdict.
+
+State inference and forecast explicitly. Never invent a source, quote, number, customer, result, experience, partnership, URL, or publication state. If support is unavailable, narrow/remove the claim or block promotion.
+
+## Commission gate
+
+Freeze before prose:
+
+- subject and first-party origin or research delta;
+- one thesis, stakes, reader baseline, and reader consequence;
+- strongest informed objection;
+- brand/property, audience, cluster, canonical URL, related pages, and cannibalization decision;
+- intent, entities, questions, internal-link role, and search-result gap;
+- source ledger and typed claim ledger;
+- offer/affiliate relationship or `none`;
+- media necessity, rights boundary, authority, and freshness window.
+
+Proceed only when the piece has original reporting, data, working artifacts, verified experience, uncommon examples, a consequential decision, or proprietary synthesis. Style cannot repair missing authority.
+
+## Article graph
+
+1. Reconstruct canonical context and existing URLs.
+2. Capture current primary sources and a dated SERP/competitor/community signal packet where relevant.
+3. Pass the commission gate and freeze the brief/claims.
+4. Draft from evidence: direct answer or earned thesis -> evidence/context -> mechanism -> implications/trade-offs -> examples -> reader transfer.
+5. Design media only when it adds evidence, emotion, or explanatory power.
+6. Run independent truth/rights, editorial/ICP, SEO/GEO, visual, and production lanes.
+7. Allow one substantive editorial rewrite; return weak work to reporting or hold.
+8. Create a pull request and inspect the rendered preview when authority permits.
+9. Publish/distribute only within authority and capture remote evidence.
+10. Observe T+0, T+7, T+28, and T+90; append learning without rewriting the original hypothesis.
+
+## Search and AI-discovery position
+
+Google states that established SEO fundamentals apply to AI Overviews and AI Mode, eligible pages must be indexed and snippet-eligible, and no special AI schema, AI text file, or artificial chunking is required. Google says it ignores `llms.txt`.
+
+- [Google AI optimization guide](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide), updated 2026-07-10.
+- [AI features and your website](https://developers.google.com/search/docs/appearance/ai-features), updated 2025-12-10.
+
+AI-assisted production is not prohibited as a method. Scaled automation created primarily to manipulate rankings can violate spam policy. Require accuracy, quality, relevance, metadata, disclosure where expected, and real information gain.
+
+- [Generative AI content guidance](https://developers.google.com/search/docs/fundamentals/using-gen-ai-content), updated 2025-12-10.
+- [People-first content guidance](https://developers.google.com/search/docs/fundamentals/creating-helpful-content), updated 2025-12-10.
+- [Google spam policies](https://developers.google.com/search/docs/essentials/spam-policies), updated 2026-05-15.
+
+Operational rules:
+
+- satisfy intent with substantial canonical pages and clear, independently legible answer units;
+- preserve identifiable author/reviewer, sources, method, dates, and update history;
+- generate JSON-LD from the same record that renders visible content;
+- use only supported, accurate schema; rich results are never guaranteed;
+- do not force FAQ sections or FAQ schema; Q&A is valid only when the reader needs it;
+- use contextual crawlable internal links; prevent orphans, duplicates, redirect chains, and keyword-stuffed anchors;
+- validate rendered HTTP 200, canonical, robots/index/snippet controls, sitemap/lastmod, metadata, schema, links, images, mobile output, and runtime errors;
+- prefer server/static output for essential article content;
+- never promise rank, traffic, or AI citation.
+
+## AI crawler controls
+
+Treat discovery and training controls independently:
+
+- allow `OAI-SearchBot` for ChatGPT Search visibility when desired; `GPTBot` is a separate training-use control: [OpenAI crawler documentation](https://developers.openai.com/api/docs/bots);
+- allow `PerplexityBot` for Perplexity search visibility when desired; `Perplexity-User` is a distinct user-triggered fetcher: [Perplexity crawler documentation](https://docs.perplexity.ai/docs/resources/perplexity-crawlers);
+- validate published IP/signature and WAF behavior instead of trusting user-agent text alone;
+- treat `llms.txt` as optional ecosystem metadata, never as a substitute for indexable HTML, sitemaps, structured data, or crawler access.
+
+## Images and media
+
+Every article needs deliberate social/metadata imagery, but not every article needs a decorative on-page hero or infographic. Visuals must reveal evidence, carry emotion unavailable in prose, or make a mechanism materially easier to understand.
+
+Use high-quality relevant images near supporting text, descriptive filenames, contextual alt text, stable crawlable URLs, and standard image markup. Maintain representative high-resolution 16:9, 4:3, and 1:1 variants where the publisher supports them. Keep clean editorial/schema imagery separate from text-led social cards.
+
+- [Google Images guidance](https://developers.google.com/search/docs/appearance/google-images), updated 2026-03-02.
+- [Article structured data](https://developers.google.com/search/docs/appearance/structured-data/article).
+
+Preserve stable asset/version/rendition identity, provenance, rights, consent, checksum, dimensions, alt text, approval, semantic placement, and rollback. Never fabricate documentary evidence.
+
+## Digital PR and affiliates
+
+Earn links with assets worth citing: original research, datasets, benchmarks, open tools, calculators, templates, primary interviews, definitive maps, maintained reference pages, and uncommon visual explanations.
+
+Reject paid ranking credit, automated links, excessive exchanges, low-quality directories, disguised advertorials, and mass low-context outreach. Qualify paid/affiliate links with `rel="sponsored"` or appropriate `nofollow`; use `ugc` for user-generated links. Affiliate work needs original decision value, verified destinations/terms, explicit disclosure, and proportional fit.
+
+- [Qualifying outbound links](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links).
+
+## Distribution and measurement
+
+Adapt by medium; do not paste the same article summary everywhere. Preserve content ID, source version, channel/account, copy version, media rendition IDs, canonical URL/UTM, disclosure, approval, schedule, remote result, and final URL.
+
+Separate:
+
+- discovery: index/canonical, Google Web, Google generative-AI reporting where available, Bing AI citations, referrals, earned links;
+- consumption/trust: qualified sessions, return, subscriptions, saves/shares/replies, expert response, branded demand;
+- commercial: CTA, lead/trial/product, affiliate outbound/revenue, assisted conversion, contribution after production/maintenance cost.
+
+Google Web/Search Console and GA4 will not match exactly; measure their distinct roles. Bing citation count is not rank or authority.
+
+- [Google Generative AI Performance report](https://support.google.com/webmasters/answer/16984139?hl=en).
+- [Search Console and Analytics](https://developers.google.com/search/docs/monitor-debug/google-analytics-search-console).
+- [Bing AI Performance](https://blogs.bing.com/webmaster/February-2026/Introducing-AI-Performance-in-Bing-Webmaster-Tools-Public-Preview), 2026-02-10.
+
+Annotate algorithm updates, data incidents, migrations, campaigns, and seasonality before diagnosis.
+
+## Scale protocol
+
+For more than three pieces:
+
+1. build a topic/entity/URL graph and existing-content inventory;
+2. define cluster sources, unique contribution, internal-link roles, commercial path, and maintenance cost;
+3. prioritize by reader pain, earned authority, information gap, linkability, conversion relevance, and evidence readiness;
+4. release a proof wave of up to three;
+5. observe indexing, qualified engagement, citations/referrals, assisted conversion, and editorial feedback;
+6. expand in bounded waves with semantic-duplication and cannibalization checks.
+
+Use a 3/3/4 evidence cadence for ten pieces. Treat 200 pieces as a maintained portfolio with cluster owners, refresh budgets, and kill thresholds—not one generation run.
+
+## Status and evidence receipt
+
+Use `SEED`, `COMMISSION`, `DRAFT`, `READY_FOR_OPERATOR`, `PREVIEW_LIVE`, `PUBLISHED`, `DISTRIBUTION_STAGED`, `DISTRIBUTED`, `HOLD`, or `KILL`. Reserve live states for confirmed external evidence.
+
+Return the publishable object or preview first, then a compact receipt: sources read, claims changed/removed, asset IDs, checks, remote writes/URLs, blockers, rollback, and next measurement event.

--- a/skills/blog-writing/SKILL.md
+++ b/skills/blog-writing/SKILL.md
@@ -1,14 +1,6 @@
 ---
-name: Blog Writing
+name: blog-writing
 description: Create evidence-bound, distinctive articles that serve readers, remain faithful to the active creator voice, and are ready for search, AI discovery, governed media, publication, distribution, and measurement
-version: 2.0.0
-triggers:
-  - "blog post"
-  - "write blog"
-  - "create article"
-  - "blog article"
-  - "research and write"
-  - "skill:blog-writing"
 ---
 
 # Blog Writing

--- a/skills/blog-writing/SKILL.md
+++ b/skills/blog-writing/SKILL.md
@@ -1,237 +1,96 @@
 ---
 name: Blog Writing
-description: Create SEO-optimized blog posts that engage readers and rank in search results
-version: 1.0.0
+description: Create evidence-bound, distinctive articles that serve readers, remain faithful to the active creator voice, and are ready for search, AI discovery, governed media, publication, distribution, and measurement
+version: 2.0.0
 triggers:
   - "blog post"
   - "write blog"
   - "create article"
   - "blog article"
+  - "research and write"
   - "skill:blog-writing"
 ---
 
 # Blog Writing
 
-## Purpose
+## Governing contract
 
-This skill transforms topics into polished, SEO-optimized blog posts that:
-- Engage readers from headline to CTA
-- Rank in search engine results
-- Establish thought leadership
-- Drive organic traffic and conversions
+Read `docs/content-intelligence.md` before drafting and create `templates/content/article-packet.json` as the working state. Optimize for a source-visible unique contribution, not a word count or keyword quota.
 
-## When to Use This Skill
+Default authority is `DRAFT`. Do not publish, deploy, distribute, or claim a live URL unless the operator explicitly grants that level or a checked-in policy already does.
 
-- Creating educational how-to guides
-- Writing thought leadership pieces
-- Producing listicles and comparison posts
-- Writing case studies and success stories
-- Creating evergreen content for SEO
-- Publishing news commentary and analysis
+## Commission before prose
 
-## Core Concepts
+Freeze:
 
-### SEO-First Structure
+- canonical creator/property, repository/CMS, audience, cluster, and existing related URLs;
+- first-party origin or research delta;
+- one thesis, stakes, reader baseline, reader consequence, and strongest objection;
+- current primary sources and typed material claims;
+- primary intent, entities, questions, internal-link role, and result-set gap;
+- offer/affiliate relationship or `none`;
+- visual necessity, rights boundary, publication authority, and freshness rule.
 
-```typescript
-interface BlogPost {
-  title: string;           // Keyword-rich, 50-60 chars
-  metaDescription: string; // 150-160 chars, includes CTA
-  headings: H2[];          // 3-7 H2s for readability
-  paragraphs: Paragraph[]; // 2-4 sentences each
-  keywords: string[];      // Primary + 3-5 secondary
-  links: ExternalLink[];   // 2-4 authoritative sources
-}
-```
+Return `COMMISSION`, `HOLD`, or `KILL` when evidence or distinction is missing. Never invent first-hand experience, results, quotations, sources, affiliate terms, or publication state.
 
-### The Skyscraper Technique
+## Research
 
-1. Find top-ranking content for target keyword
-2. Identify gaps and improvement opportunities
-3. Create comprehensive content (2x better)
-4. Reach out for backlinks
+Use the closest authoritative source: verified first-party artifacts and telemetry, canonical repository/product records, primary external sources, then inspectable synthesis. Community posts are language and demand signals until corroborated.
 
-### Content Pillar Strategy
+Read full sources and record publication/update and retrieval dates. Build an atomic claim ledger before drafting. Label fact, first-party evidence, inference, opinion, forecast, and community signal distinctly.
 
-```markdown
-Pillar Page (10,000+ words)
-├── Topic Cluster Content 1 (1,500 words)
-├── Topic Cluster Content 2 (1,500 words)
-├── Topic Cluster Content 3 (1,500 words)
-└── Topic Cluster Content 4 (1,500 words)
-```
+## Drafting
 
-## Patterns
+Let the subject determine form. Default reasoning path:
 
-### Pattern 1: How-To Guide Structure
+`Direct answer or earned thesis -> evidence/context -> mechanism/architecture -> implications and trade-offs -> examples/proof -> reader transfer -> sources/next action`
 
-```markdown
-# How to [Achieve Desired Outcome]: [Timeframe or Method]
+Use descriptive headings, concise tables for exact comparison, steps only when order matters, and diagrams only when relationships are the reward. Put evidence beside the claims it supports.
 
-## What You'll Learn
-- Learning outcome 1
-- Learning outcome 2
-- Learning outcome 3
+Use the active creator voice and real experience only. Remove generic scene-setting, keyword-led openings, slogan stacks, synthetic anecdotes, inflated certainty, tool inventories without reader value, and repetitive conclusions.
 
-## Step 1: [First Major Step]
-### What You're Doing
-[Clear explanation in 2-3 sentences]
+## Search and AI discovery
 
-### Why It Matters
-[Brief rationale]
+Apply `skills/seo-optimization/SKILL.md`. Satisfy actual intent and entity questions without forcing keywords into headings or prose. Do not manufacture FAQ sections, fixed link counts, title lengths, keyword density, or article length. Those are context-dependent editorial choices, not universal gates.
 
-### How to Do It
-1. [Sub-step with detail]
-2. [Sub-step with detail]
-3. [Sub-step with detail]
+## Media
 
-### Pro Tips
-- Insider technique
-- Common mistake to avoid
+Every article needs deliberate metadata/social imagery. On-page heroes, diagrams, screenshots, infographics, and video are conditional on evidence, emotion, or explanatory value.
 
-## Step 2: [Second Major Step]
-[Same structure]
+Preserve asset/version/rendition IDs, provenance, rights, consent, checksum, dimensions, alt text, approval, semantic placement, and rollback. Use a clean representative article image separately from text-led social cards where applicable.
 
-## Common Challenges
-| Challenge | Solution |
-|-----------|----------|
-| [Challenge 1] | [Solution 1] |
-| [Challenge 2] | [Solution 2] |
+## Independent review
 
-## FAQ
-**Q: [Common question]**
-A: [Direct answer]
+Require categorical verdicts from:
 
-## Your Turn
-[Actionable CTA with next step]
-```
+- truth and rights;
+- commissioning editor and ICP reader;
+- SEO/GEO;
+- art critic when media exists;
+- production verifier when files or remote state exist.
 
-### Pattern 2: Listicle Structure
+The writer cannot certify its own work. Allow one substantive editorial rewrite. Continue deterministic fixes until pass or blocker.
 
-```markdown
-# [Number] [Powerful Adjective] Ways to [Desired Outcome]
+## Output
 
-## Why [Desired Outcome] Matters
-[Compelling hook, 2-3 paragraphs]
+Return the article or verified preview first, followed by a compact evidence receipt: status, authority, canonical property/path, sources read, claims changed/removed, asset IDs, checks, remote writes/URLs, blockers, rollback, and next measurement event.
 
-## The Methods
-1. **[Method 1]**
-   - Description with context
-   - When to use this approach
-   - Example implementation
+Use `SEED`, `COMMISSION`, `DRAFT`, `READY_FOR_OPERATOR`, `PREVIEW_LIVE`, `PUBLISHED`, `DISTRIBUTION_STAGED`, `DISTRIBUTED`, `HOLD`, or `KILL`.
 
-2. **[Method 2]**
-   - [Same structure]
+## Anti-patterns
 
-3. **[Method 3]**
-   - [Same structure]
+- Skyscraper copying or “2x longer” as a strategy.
+- Thin work padded to a minimum word count.
+- Keyword-density targets, LSI-keyword language, or repeated exact-match anchors.
+- Guaranteed rankings, traffic, conversions, or AI citations.
+- Mandatory TL;DR, question H2s, FAQ, listicle, CTA, or template when the subject does not earn it.
+- Auto-publishing because generation completed.
+- Treating a humanizer or blacklist as the quality system.
 
-[...continue through all methods]
+## Related surfaces
 
-## My Top Pick
-[Reasoning for best method with evidence]
-
-## Quick Implementation Checklist
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-```
-
-## Step-by-Step Process
-
-1. **Keyword Research**
-   - Use Ahrefs/Semrush for volume and difficulty
-   - Find long-tail variations
-   - Analyze search intent (informational, navigational, transactional)
-
-2. **Content Brief Creation**
-   - Define primary keyword
-   - Identify 3-5 secondary keywords
-   - Outline H2 structure
-   - Specify word count target (1,500-3,000 words)
-
-3. **Drafting**
-   - Write H2s first as outline
-   - Expand each section with 2-4 paragraphs
-   - Include examples, statistics, expert quotes
-
-4. **SEO Optimization**
-   - Place primary keyword in title, H1, first paragraph, conclusion
-   - Add secondary keywords in H2s and naturally throughout
-   - Include 2-4 external links to authoritative sources
-   - Add internal links to related content
-
-5. **Review and Refine**
-   - Check readability (aim for Grade 6-8)
-   - Verify all claims have citations
-   - Test mobile formatting
-   - Run through SEO checklist
-
-## FrankX Application
-
-```markdown
-# How to Create Transformative Content That Changes Minds
-
-**[FrankX Brand Voice: Provocative, visionary]**
-
-The content landscape has shifted. Yesterday's SEO tricks won't work tomorrow.
-
-Here's how to create content that doesn't just rank—it transforms.
-
-## Why Traditional Content Fails
-
-Most content gets ignored because it:
-
-- States the obvious
-- Lacks distinct perspective
-- Fails to challenge assumptions
-
-## The FrankX Approach
-
-[Your brand-specific framework with consciousness/transformation themes]
-
-## Quick Implementation
-1. Lead with a provocative premise
-2. Back it with evidence
-3. Connect to transformation
-4. End with actionable framework
-```
-
-## Anti-Patterns
-
-| Bad Practice | Why It's Bad | Better Approach |
-|--------------|--------------|-----------------|
-| Keyword stuffing | Hurts readability, penalized by Google | Natural keyword integration |
-| Generic introductions | Fails to hook readers | Start with hook, story, or question |
-| Thin content (<1,000 words) | Doesn't satisfy search intent | Comprehensive 1,500+ words |
-| No clear CTA | Misses conversion opportunity | Specific, actionable next step |
-| Ignoring featured snippets | Loses valuable SERP real estate | Answer question in 50 words |
-
-## Quick Commands
-
-```bash
-# Create blog post from topic
-skill:blog-writing, create a how-to guide about [TOPIC]
-
-# Write thought leadership piece
-skill:blog-writing, write an opinion piece on [TREND]
-
-# Generate listicle
-skill:blog-writing, create a listicle about [CATEGORY]
-
-# SEO audit existing content
-skill:seo-optimization, audit my blog post at [URL]
-```
-
-## Related Skills
-
-- `seo-optimization` - Optimize content for search engines
-- `content-strategy` - Plan content calendar and topics
-- `social-media` - Promote blog posts across platforms
-- `newsletter` - Distribute via email
-
-## Resources
-
-- `resources/templates.md` - Blog post templates for different types
-- `resources/seo-checklist.md` - Pre-publication SEO verification
-- `resources/examples.md` - High-performing blog post examples
+- `docs/content-intelligence.md`
+- `templates/content/article-packet.json`
+- `skills/seo-optimization/SKILL.md`
+- `workflows/content/research-to-article.yaml`
+- `/article-creator`, `/publish`, `/seo-check`

--- a/skills/seo-optimization/SKILL.md
+++ b/skills/seo-optimization/SKILL.md
@@ -1,333 +1,124 @@
 ---
 name: SEO Optimization
-description: Optimize content for search engines to increase organic traffic and rankings
-version: 1.0.0
+description: Improve search and AI-discovery eligibility, usefulness, technical integrity, entity consistency, internal links, digital PR, and measurable outcomes using current first-party guidance without ranking guarantees or keyword-density tactics
+version: 2.0.0
 triggers:
   - "seo"
-  - "seo optimization"
+  - "geo"
+  - "aeo"
+  - "AI search"
   - "search optimization"
   - "keyword research"
   - "rank higher"
+  - "backlinks"
   - "skill:seo-optimization"
 ---
 
-# SEO Optimization
-
-## Purpose
-
-Optimize content to rank higher in search engines and drive organic traffic:
-- Research and target the right keywords
-- Structure content for search intent
-- Build technical SEO foundations
-- Earn quality backlinks
-
-## When to Use This Skill
-
-- Optimizing existing blog posts
-- Planning new content around keywords
-- Technical SEO audits
-- Competitor keyword analysis
-- Local SEO optimization
-- E-commerce product pages
-
-## Core Concepts
-
-### The SEO Pyramid
-
-```
-                    ┌─────────────┐
-                    │  BACKLINKS  │ ← Authority building
-                    └──────┬──────┘
-               ┌───────────┼───────────┐
-          ┌────┴────┐ ┌────┴────┐ ┌────┴────┐
-          │Content  │ │On-Page  │ │Technical│
-          │Quality  │ │Elements │ │ SEO     │
-          └─────────┘ └─────────┘ └─────────┘
-                    ┌───────────┐
-                    │ KEYWORDS  │ ← Foundation
-                    └───────────┘
-```
-
-### Search Intent Types
-
-```typescript
-type SearchIntent =
-  | 'informational'    // "What is..." - Answer questions
-  | 'navigational'     // "Netflix login" - Brand queries
-  | 'transactional'    // "Buy iPhone" - Purchase intent
-  | 'commercial'       // "Best laptop 2024" - Research before buy
-
-function matchIntent(keyword: string, content: Content): boolean {
-  // Informational: How-to guides, explanations
-  // Navigational: Brand pages, login
-  // Transactional: Pricing, demo, buy
-  // Commercial: Comparisons, reviews
-}
-```
-
-## Patterns
-
-### Pattern 1: On-Page SEO Checklist
-
-```markdown
-## Title Tag (50-60 characters)
-<title>[Primary Keyword] - [Benefit] | [Brand]</title>
-
-## Meta Description (150-160 characters)
-<meta name="description" content="[Compelling description with keywords and CTA]">
-
-## Heading Structure
-<H1>[Title matching title tag]</H1>
-<H2>[Major section - includes secondary keywords]</H2>
-<H3>[Sub-section - includes related keywords]</H3>
-<H2>[Another major section]</H2>
-...
-
-## Content Optimization
-✓ Primary keyword in first paragraph
-✓ Secondary keywords in 2-3 paragraphs each
-✓ Keywords in bold/strong (2-3 occurrences)
-✓ Related keywords naturally throughout
-✓ LSI keywords for context
-
-## Image Optimization
-✓ Alt text with keywords
-✓ Compressed file sizes
-✓ Descriptive filenames
-✓ Lazy loading for below-fold images
-
-## Internal Linking
-✓ 2-4 internal links to related content
-✓ Anchor text varies naturally
-✓ Links to pillar/cluster content
-
-## Technical Elements
-✓ Fast loading (<3 seconds)
-✓ Mobile responsive
-✓ SSL certificate (HTTPS)
-✓ XML sitemap submitted
-✓ Robots.txt configured
-✓ Canonical tags for duplicates
-```
-
-### Pattern 2: Keyword Research Framework
-
-```typescript
-interface KeywordData {
-  keyword: string;           // Target keyword
-  volume: number;            // Monthly searches
-  difficulty: number;        // 0-100 scale
-  cpc: number;               // Cost per click
-  intent: SearchIntent;      // Type of search
-  serpFeatures: string[];    // Featured snippets, etc.
-}
-
-const researchKeywords = (topic: string): KeywordData[] => {
-  return [
-    // Primary keyword (high volume, high difficulty)
-    { keyword: `${topic}`, volume: 10000, difficulty: 70, intent: 'informational' },
-    // Long-tail keyword (low volume, low difficulty)
-    { keyword: `how to ${topic} for beginners`, volume: 1000, difficulty: 30, intent: 'informational' },
-    // Commercial intent
-    { keyword: `best ${topic} tools`, volume: 5000, difficulty: 60, intent: 'commercial' },
-    // Question keyword (featured snippet)
-    { keyword: `what is ${topic}`, volume: 3000, difficulty: 40, intent: 'informational' },
-  ];
-}
-```
-
-### Pattern 3: Content Brief Template
-
-```markdown
-# Content Brief: [Target Keyword]
-
-## Basic Info
-- Primary Keyword: [keyword]
-- Target Search Intent: [informational/navigational/transactional/commercial]
-- Target Word Count: [1,500-2,500 words]
-- Suggested Title: "[title with keyword]"
-- Target Ranking: [Position 1-3]
-
-## Keyword Strategy
-**Primary Keyword:** [keyword]
-**Secondary Keywords:**
-- [keyword 1]
-- [keyword 2]
-- [keyword 3]
-
-**Related Terms to Include:**
-- [term 1]
-- [term 2]
-- [term 3]
-
-**Questions to Answer:**
-- [Question 1]
-- [Question 2]
-- [Question 3]
-
-## Content Structure
-**H2 Outline:**
-1. [Section about X]
-2. [Section about Y]
-3. [Section about Z]
-
-**Featured Snippet Target:**
-Question: "[Question to answer]"
-Answer: "[50-word answer - direct, concise]"
-
-## Competitor Analysis
-**Top 3 Ranking Pages:**
-1. [URL 1] - Strengths, weaknesses
-2. [URL 2] - Strengths, weaknesses
-3. [URL 3] - Strengths, weaknesses
-
-**Content Gaps to Exploit:**
-- [Gap 1]
-- [Gap 2]
-
-## Links to Include
-**Internal Links (2-4):**
-- [Link 1 to pillar/cluster content]
-- [Link 2 to related content]
-
-**External Links (2-4):**
-- [Link to authoritative source 1]
-- [Link to authoritative source 2]
-
-## Success Metrics
-- Target word count: [number]
-- Readability grade: [6-8]
-- Keyword density: [1-2%]
-- Images: [3-5 with optimized alt text]
-```
-
-## Step-by-Step Process
-
-1. **Keyword Research**
-   - Use Ahrefs/Semrush/Moz for data
-   - Find keywords with right volume/difficulty balance
-   - Analyze search intent
-   - Identify content gaps
-
-2. **Competitive Analysis**
-   - Analyze top-ranking pages
-   - Identify what makes them rank
-   - Find gaps to outrank them
-   - Note their word count and structure
-
-3. **Content Planning**
-   - Create detailed content briefs
-   - Define target word count
-   - Plan headings and structure
-   - Specify internal/external links
-
-4. **On-Page Optimization**
-   - Include keywords in title/meta
-   - Structure with H2s/H3s
-   - Optimize images
-   - Add internal links
-
-5. **Technical SEO**
-   - Fix crawl errors
-   - Improve page speed
-   - Ensure mobile-friendliness
-   - Submit sitemap
-
-6. **Link Building**
-   - Create link-worthy content
-   - Reach out for backlinks
-   - Build internal links
-   - Monitor backlink profile
-
-## FrankX Application
-
-```markdown
-# SEO Strategy: [TOPIC] for [AUDIENCE]
-
-## The FrankX SEO Philosophy
-
-Most SEO is playing defense.
-
-FrankX plays offense.
-
-**Our approach:**
-
-1. Own the narrative, not just the keywords
-2. Create content so good they have to link
-3. Build topical authority, not just page authority
-
-## Target Keyword Clusters
-
-**Pillar Page:** "[Ultimate Guide to TOPIC]"
-- 10,000+ words
-- Comprehensive coverage
-- Links to all cluster content
-
-**Cluster Content:**
-- "How to [TOPIC] for Beginners" (1,500 words)
-- "[TOPIC] Mistakes to Avoid" (1,200 words)
-- "The Science Behind [TOPIC]" (1,800 words)
-- "[TOPIC] Case Studies" (2,000 words)
-
-## Link Building Strategy
-
-**Resource Page Outreach:**
-- Create ultimate resource pages
-- Pitch to relevant resource pages
-- Track responses and follow up
-
-**HARO/Connectively:**
-- Position as expert source
-- Provide valuable insights
-- Earn backlinks from journalists
-
-**Broken Link Building:**
-- Find broken links in niche
-- Offer content as replacement
-- Easy wins for backlinks
-```
-
-## Anti-Patterns
-
-| Bad Practice | Why It's Bad | Better Approach |
-|--------------|--------------|-----------------|
-| Keyword stuffing | Penalized by Google | Natural keyword usage |
-| Ignoring search intent | Low engagement metrics | Match content to intent |
-| Thin content (<1,000 words) | Doesn't satisfy users | Comprehensive 1,500+ words |
-| No internal linking | Weak site structure | Connect related content |
-| Duplicate content | Confuses search engines | Use canonical tags |
-| Ignoring mobile | Poor rankings, UX | Mobile-first design |
-| Slow page speed | High bounce rate | Optimize images, minify |
-
-## Quick Commands
-
-```bash
-# Research keywords for topic
-skill:seo-optimization, research keywords for [TOPIC]
-
-# Audit existing content
-skill:seo-optimization, audit my blog post at [URL]
-
-# Create content brief
-skill:seo-optimization, create a content brief for [KEYWORD]
-
-# Optimize existing page
-skill:seo-optimization, optimize my page [URL] for [KEYWORD]
-
-# Find link building opportunities
-skill:seo-optimization, find link building opportunities for [TOPIC]
-```
-
-## Related Skills
-
-- `blog-writing` - Create SEO-optimized content
-- `content-strategy` - Plan keyword-targeted content
-- `social-media` - Promote content for backlinks
-- `video-script` - Create YouTube SEO content
-
-## Resources
-
-- `resources/templates.md` - Content brief templates
-- `resources/checklists.md` - Pre-publication SEO checklist
-- `resources/tools.md` - SEO tool recommendations
-- `resources/competitor-analysis.md` - Competitor research framework
+# SEO and AI Discovery
+
+## Governing contract
+
+Read `docs/content-intelligence.md`. Use current first-party search and crawler documentation for any unstable rule, feature, limit, or claim.
+
+Never promise rank, traffic, rich results, or AI citation. Forecast with explicit assumptions and confidence, then preserve predicted and actual outcomes separately.
+
+## Current position
+
+Google states that existing SEO fundamentals apply to AI Overviews and AI Mode. Pages must be indexed and snippet-eligible. No special AI schema, AI text file, or artificial chunking is required, and Google says it ignores `llms.txt`.
+
+- [Google AI optimization guide](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide), updated 2026-07-10.
+- [AI features and your website](https://developers.google.com/search/docs/appearance/ai-features), updated 2025-12-10.
+
+AI-assisted production is not prohibited as a method. Scaled automation produced primarily to manipulate ranking can violate spam policy. Require information gain, accuracy, source visibility, relevant metadata, and disclosure where expected.
+
+- [Generative AI content guidance](https://developers.google.com/search/docs/fundamentals/using-gen-ai-content), updated 2025-12-10.
+- [People-first content guidance](https://developers.google.com/search/docs/fundamentals/creating-helpful-content), updated 2025-12-10.
+- [Spam policies](https://developers.google.com/search/docs/essentials/spam-policies), updated 2026-05-15.
+
+## Opportunity packet
+
+Capture:
+
+- query, locale, device posture, date, dominant intent, result types, source diversity;
+- competent-reader expectation and weak/duplicated result coverage;
+- creator's earned information gain and primary evidence;
+- canonical URL, existing adjacent pages, consolidation/cannibalization decision;
+- entities, subquestions, answer units, internal-link role, and freshness burden;
+- likely conversion or authority role, not only estimated traffic.
+
+Treat community language and search snippets as discovery evidence, not factual support.
+
+## Rendered technical gate
+
+Verify:
+
+- public HTTP 200 and meaningful server/static main content;
+- index/noindex and snippet controls;
+- canonical, redirects, absolute canonical sitemap URL, truthful `lastmod`;
+- title, description, heading structure, locale, author/profile identity;
+- crawlable `<a href>` internal links, no orphan important pages, no broken links or redirect chains;
+- accessible images in standard markup with stable URLs, useful alt text, captions/credits when needed;
+- visible-content-consistent JSON-LD and no schema errors;
+- mobile output, performance, hydration/runtime errors, and analytics events.
+
+Robots exclusion is not a deindexing method. Use `noindex` while allowing the crawler to read it when deindexing is intended.
+
+## Content and entities
+
+- Lead with the actual answer or earned thesis.
+- Use clear sections inside a substantial canonical page; do not create thin fan-out pages.
+- Preserve exact entity names, dates, units, scope, author, organization, sources, method, and update history.
+- Use `Article`/`BlogPosting`, profile, organization, breadcrumb, or media schema only when supported and visible.
+- Do not force FAQ sections or FAQ schema. Google reported FAQ rich results stopped appearing in May 2026; Q&A still belongs where readers need it.
+- Internal links should be contextual and descriptive. There is no magic link count.
+
+## AI crawler controls
+
+- `OAI-SearchBot` controls ChatGPT Search visibility; `GPTBot` is a separate training-use control: [OpenAI crawler docs](https://developers.openai.com/api/docs/bots).
+- `PerplexityBot` controls Perplexity search crawling; `Perplexity-User` is distinct: [Perplexity crawler docs](https://docs.perplexity.ai/docs/resources/perplexity-crawlers).
+- Validate published IP/signature guidance and WAF behavior; do not trust user-agent text alone.
+- `llms.txt` may remain optional ecosystem metadata but does not replace HTML, schema, crawler access, or sitemaps.
+
+## Images
+
+Use high-quality relevant images near supporting text, descriptive filenames, contextual alt text, stable crawlable URLs, and standard markup. Keep the clean representative article/schema image separate from text-led social cards. Preserve high-resolution 16:9, 4:3, and 1:1 variants where the publisher supports them.
+
+- [Google Images guidance](https://developers.google.com/search/docs/appearance/google-images), updated 2026-03-02.
+- [Article structured data](https://developers.google.com/search/docs/appearance/structured-data/article).
+
+## Digital PR and links
+
+Earn links through original datasets, benchmarks, tools, calculators, templates, primary interviews, definitive maps, maintained references, and uncommon visual explanations.
+
+Reject paid ranking credit, automated link creation, excessive exchanges, low-quality directories, disguised advertorials, and mass low-context outreach. Qualify paid and affiliate links with `sponsored` or appropriate `nofollow`; use `ugc` for user-generated links.
+
+- [Qualifying outbound links](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links).
+
+## Measurement
+
+Separate:
+
+- Google Search Console Web impressions/clicks/queries/pages;
+- Google Generative AI Performance where available;
+- Bing AI citations and grounding queries, which are not rank or authority;
+- analytics sessions, engagement, actions, and conversions;
+- AI/search/social/referral sources, earned links, affiliate/product value.
+
+Annotate algorithm updates, data incidents, migrations, campaigns, and seasonality before diagnosis.
+
+- [Google Generative AI Performance](https://support.google.com/webmasters/answer/16984139?hl=en).
+- [Search Console and Analytics](https://developers.google.com/search/docs/monitor-debug/google-analytics-search-console).
+- [Bing AI Performance](https://blogs.bing.com/webmaster/February-2026/Introducing-AI-Performance-in-Bing-Webmaster-Tools-Public-Preview), 2026-02-10.
+
+## Output
+
+Return opportunity evidence, technical findings, content/entity findings, link graph, prioritized actions, forecast with assumptions, executed fixes, verification, and measurement date. Distinguish explicit guidance from implementation inference.
+
+## Remove these legacy patterns
+
+- keyword density, LSI keywords, bolding keywords, and universal title/meta/word-count formulas;
+- fixed minimum internal/external link or image counts;
+- manual `site:` result-count scraping as an indexing metric;
+- asking an AI product whether it mentions the brand as a measurement system;
+- mandatory FAQPage schema or “featured snippet” copy blocks;
+- automatically interpreting an SEO score as publication quality.

--- a/skills/seo-optimization/SKILL.md
+++ b/skills/seo-optimization/SKILL.md
@@ -1,17 +1,6 @@
 ---
-name: SEO Optimization
+name: seo-optimization
 description: Improve search and AI-discovery eligibility, usefulness, technical integrity, entity consistency, internal links, digital PR, and measurable outcomes using current first-party guidance without ranking guarantees or keyword-density tactics
-version: 2.0.0
-triggers:
-  - "seo"
-  - "geo"
-  - "aeo"
-  - "AI search"
-  - "search optimization"
-  - "keyword research"
-  - "rank higher"
-  - "backlinks"
-  - "skill:seo-optimization"
 ---
 
 # SEO and AI Discovery

--- a/templates/content/article-packet.json
+++ b/templates/content/article-packet.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "1.0.0",
+  "content_id": "cnt_example_replace_me",
+  "status": "SEED",
+  "authority": "DRAFT",
+  "brand": {
+    "brand_id": "replace-me",
+    "domain": "replace-me.example",
+    "repository": "blocked",
+    "deployment_project": "blocked",
+    "editorial_record": "blocked"
+  },
+  "brief": {
+    "working_title": "Replace with an earned title",
+    "subject": "Replace with the exact subject",
+    "origin": "Replace with first-party origin or research delta",
+    "thesis": "Replace with one governing thesis",
+    "reader": "Replace with the competent reader",
+    "reader_baseline": "Replace with what the reader already believes",
+    "reader_delta": "Replace with what changes after reading",
+    "stakes": "Replace with what is decided, risked, spent, changed, won, or lost",
+    "strongest_objection": "Replace with the strongest informed objection",
+    "commercial_relationship": "none"
+  },
+  "content_graph": {
+    "cluster_id": "cluster_replace_me",
+    "canonical_url": "blocked",
+    "existing_related_urls": [],
+    "internal_links": [],
+    "entities": []
+  },
+  "search": {
+    "primary_intent": "Replace with one intent",
+    "query_set": [],
+    "serp_snapshot": {
+      "captured_at": "blocked",
+      "locale": "blocked",
+      "device": "blocked",
+      "dominant_intent": "blocked",
+      "information_gap": "blocked"
+    },
+    "answer_units": [],
+    "structured_data": ["Article"],
+    "indexation": "index",
+    "crawler_policy_checked": false
+  },
+  "sources": [],
+  "claims": [],
+  "article": {
+    "source_path": "blocked",
+    "canonical_title": "blocked",
+    "description": "blocked",
+    "author_id": "blocked",
+    "published_at": null,
+    "modified_at": null
+  },
+  "media": [],
+  "affiliates": [],
+  "distribution": [],
+  "reviews": [],
+  "publication": {
+    "branch": "blocked",
+    "pull_request": "blocked",
+    "preview_url": "blocked",
+    "live_url": "blocked",
+    "verified_at": null,
+    "rollback": "blocked"
+  },
+  "measurement": {
+    "hypothesis": "blocked",
+    "primary_metric": "blocked",
+    "guardrails": [],
+    "snapshots": [],
+    "freshness_review_at": "blocked",
+    "freshness_triggers": []
+  },
+  "blocked": [
+    "Replace template values with connected evidence before promotion beyond SEED."
+  ]
+}

--- a/workflows/content/blog-creation.yaml
+++ b/workflows/content/blog-creation.yaml
@@ -1,107 +1,35 @@
 name: blog-creation
 department: content
-version: 1.0.0
-purpose: Create a professional, SEO-optimized blog post from idea to publication
+version: 2.0.0
+purpose: Compatibility entry point for the evidence-bound Content Intelligence Article Pipeline
 
-agents:
-  - name: Researcher
-    role: Gathers information
-  - name: Writer
-    role: Creates initial draft
-  - name: Editor
-    role: Reviews and polishes
-  - name: SEO Specialist
-    role: Optimizes for search
-  - name: Publisher
-    role: Publishes to website
+contract: docs/content-intelligence.md
+canonical_workflow: workflows/content/research-to-article.yaml
+state_template: templates/content/article-packet.json
+default_authority: DRAFT
 
 steps:
-  - name: Research
-    input:
-      - Topic
-      - Target keywords
-      - Audience
+  - name: Route
     actions:
-      - Search for current information on topic
-      - Identify key points and statistics
-      - Find competitor content for reference
-      - Gather source URLs for citations
-    output: Research brief with key points and sources
+      - Read the canonical workflow in full
+      - Create the article packet before prose
+      - Execute every applicable phase without adding legacy word-count, keyword-density, FAQ, link-count, image-count, or immediate-publish gates
+    output: Canonical workflow task envelope
 
-  - name: Outline
-    input:
-      - Research brief
-      - Target length
-      - Structure
+  - name: Execute
     actions:
-      - Create article outline
-      - Define headings and subheadings
-      - Identify key sections
-      - Plan word count per section
-    output: Detailed outline with word counts
-
-  - name: Draft
-    input:
-      - Outline
-      - Tone
-      - Target audience
-    actions:
-      - Write introduction with hook
-      - Develop each section with depth
-      - Include examples and statistics
-      - Write compelling conclusion
-      - Add call-to-action
-    output: First draft (aim for target word count)
-
-  - name: Edit
-    input:
-      - First draft
-      - Style guide
-      - Brand voice
-    actions:
-      - Review for clarity and flow
-      - Improve sentence structure
-      - Fix grammar and spelling
-      - Ensure brand voice consistency
-      - Verify factual accuracy
-    output: Polished second draft
-
-  - name: SEO Optimization
-    input:
-      - Polished draft
-      - Target keywords
-    actions:
-      - Optimize title for SEO
-      - Add meta description
-      - Include keywords naturally
-      - Optimize headings structure
-      - Add internal and external links
-      - Improve readability score
-      - Add featured image suggestion
-    output: SEO-optimized final draft
-
-  - name: Publish
-    input:
-      - Final draft
-      - Publication settings
-    actions:
-      - Format for CMS
-      - Add featured image
-      - Set category and tags
-      - Schedule or publish
-      - Add to content calendar
-      - Notify relevant channels
-    output: Live published blog post
+      - Follow research-to-article from context reconstruction through independent review
+      - Preview, publish, and distribute only within resolved authority
+      - Return the publishable object or verified preview first, then the evidence receipt
+    output: Article packet and status
 
 metrics:
-  - Time to complete
-  - Word count achieved
-  - SEO score before and after
-  - Readability score
-  - Publishing status
+  - unique contribution and claim coverage
+  - review verdicts and revision count
+  - preview and publication verification
+  - qualified discovery, trust, and commercial value
+  - production and maintenance cost
 
 config:
-  default_length: 1500
-  seo_optimization: true
   publish_immediately: false
-  research_depth: medium
+  research_depth: evidence-dependent

--- a/workflows/content/research-to-article.yaml
+++ b/workflows/content/research-to-article.yaml
@@ -1,62 +1,125 @@
-name: Research to Article Pipeline
+name: Content Intelligence Article Pipeline
 slug: research-to-article
-version: "6.0.0"
+version: "7.0.0"
 description: |
-  Deep research on a topic → structured outline → draft article →
-  SEO optimization → publish-ready content.
+  Evidence-bound path from commission and current research through authored article,
+  governed media, independent review, preview, conditional publication,
+  channel-native distribution, and dated performance learning.
 
 triggers:
   - "/factory"
   - "/article-creator"
   - "research and write article"
+  - "write and publish article"
+
+contract: docs/content-intelligence.md
+state_template: templates/content/article-packet.json
+default_authority: DRAFT
 
 agents:
-  - frankx-content-creation
-  - seo_specialist
-  - content-polisher
-
-skills:
-  - content-strategy
-  - planning-with-files
+  - editor-in-chief
+  - research-lead
+  - fact-rights-reviewer
+  - seo-geo-architect
+  - author
+  - commissioning-editor
+  - visual-director
+  - production-engineer
+  - distribution-revenue-lead
+  - measurement-analyst
 
 phases:
-  - name: Research
+  - name: Task Envelope
     steps:
-      - Web search for current data and trends on the topic
-      - Gather 5-10 authoritative sources
-      - Extract key facts, statistics, and expert quotes
-      - Identify unique angle not covered by competitors
-    output: research-notes.md
+      - Resolve deliverables, creator/property, canonical repository or CMS, audience, authority, permissions, rights, timing, and success condition
+      - Inspect existing instructions, content model, related URLs, active editorial ledger, live deployment, and available performance evidence
+      - Preserve unknown or unavailable state as explicit blockers; never invent IDs, URLs, credentials, or publication state
+    output: article-packet.json
 
-  - name: Outline
+  - name: Research and Opportunity
+    parallel_lanes:
+      - Collect first-party artifacts, canonical product facts, and primary external sources
+      - Capture dated SERP, competitor, entity, question, and community-language evidence where relevant
+      - Map existing canonical URLs, cannibalization, internal-link role, offer and affiliate fit
     steps:
-      - Create H2 structure with question-based headings
-      - Plan TL;DR for the opening paragraph
-      - Map supporting evidence to each section
-      - Plan FAQ section with 5+ questions
-    output: article-outline.md
+      - Build a source ledger with publication/update and retrieval dates
+      - Build atomic claim candidates typed as fact, first_party, inference, opinion, forecast, or community_signal
+      - State information gap, strongest objection, maintenance burden, and confidence
+    output: research-and-opportunity packet
 
-  - name: Draft
+  - name: Commission Gate
     steps:
-      - Write full article following the outline
-      - Include internal links (minimum 3)
-      - Include external authority links (minimum 1)
-      - Write in FrankX voice (technical, direct, warm)
-    output: article-draft.mdx
+      - Require first-party origin, measured result, original reporting, working artifact, consequential decision, uncommon example, or proprietary synthesis
+      - Freeze one thesis, reader baseline, reader delta, stakes, canonical route, and freshness rule
+      - Return COMMISSION, HOLD, or KILL when the work cannot beat publishing nothing
+    output: frozen brief or reporting assignment
 
-  - name: Optimization
+  - name: Author and Direct Media
+    parallel_lanes:
+      - Draft from evidence using the active creator voice and subject-native structure
+      - Decide visual necessity and create governed media briefs or assets only when meaning requires them
     steps:
-      - SEO title optimization (50-60 characters)
-      - Meta description (120-160 characters)
-      - Add schema markup (Article + FAQPage)
-      - Verify keyword density and placement
-    output: article-optimized.mdx
+      - Keep facts adjacent to their sources and label inference or forecast
+      - Create deliberate metadata and social/representative image treatment
+      - Preserve article, asset, version, rendition, and placement identities
+    output: article draft and media packet
+
+  - name: Independent Review
+    parallel_lanes:
+      - Truth, rights, privacy, quotation, and disclosure
+      - Commissioning editor and ICP reader
+      - SEO/GEO, entity, crawl/render, schema, and link graph
+      - Art critic when media exists
+      - Production verifier when files or remote state exist
+    steps:
+      - Require categorical verdicts with reasons
+      - Allow one substantive editorial rewrite
+      - Continue deterministic correctness fixes until pass or exact blocker
+    output: READY_FOR_OPERATOR, COMMISSION, HOLD, or KILL
+
+  - name: Build and Preview
+    condition: authority is PREVIEW, PUBLISH, or DISTRIBUTE
+    steps:
+      - Create a content branch and smallest coherent repository change
+      - Run repository-native format, lint, type, content/schema, link, and build checks
+      - Create a pull request with evidence receipt, rollback, and unresolved risk
+      - Inspect the rendered preview on mobile and desktop, including metadata, canonical, robots, JSON-LD, images, links, and runtime errors
+    output: PREVIEW_LIVE with confirmed pull request and preview URL
 
   - name: Publish
+    condition: authority is PUBLISH or DISTRIBUTE and all release gates pass
     steps:
-      - Run quality gates (structure, SEO, voice, AEO)
-      - Generate hero image via /infogenius
-      - Deploy via /publish command
-    output: published-url
+      - Merge or release through the repository or CMS native path
+      - Verify canonical production URL serves the intended version
+      - Capture deployment, live URL, time, and rollback evidence
+    output: PUBLISHED
+
+  - name: Distribute
+    condition: authority is DISTRIBUTE and target accounts, approval, and schedule are resolved
+    steps:
+      - Create channel-native derivatives tied to the canonical content ID and source version
+      - Apply stable UTMs, disclosure, approved asset renditions, and provider-neutral distribution records
+      - Capture scheduler or channel result ID and final URL
+    output: DISTRIBUTED or DISTRIBUTION_STAGED
+
+  - name: Learn
+    condition: article is PUBLISHED
+    steps:
+      - Verify T+0 technical and measurement state
+      - Append T+7, T+28, and T+90 discovery, trust, commercial, cost, and qualitative snapshots
+      - Preserve original hypothesis and annotate algorithms, incidents, migrations, campaigns, and seasonality
+      - Decide refresh, consolidate, redirect, archive, expand, or kill
+    output: dated performance and learning records
+
+termination:
+  external_research_rounds: 2
+  substantive_editorial_rewrites: 1
+  visual_directions: 3
+  stop_on:
+    - unverifiable central claim
+    - unclear rights or consent
+    - conflicting canonical property
+    - missing authority for requested external write
+    - destructive migration
 
 output_dir: outputs/articles


### PR DESCRIPTION
## What this changes

- adds a portable content-intelligence contract and structured article packet
- upgrades blog-writing and SEO skills to source-grounded, people-first 2026 guidance
- aligns article creation, SEO review, and publishing commands with explicit authority and provenance
- makes visuals, distribution, affiliate disclosures, and measurement first-class outputs
- preserves the existing command/workflow names for backward compatibility

## Safety changes

- removes mandatory keyword-density, LSI, word-count, FAQ, and fixed-link formulas
- removes forced publishing, hard-coded FrankX copy paths, direct-to-main defaults, and fabricated live URLs
- requires source, claim, asset, disclosure, and publish checks before a piece can move forward
- treats ranking and AI-citation outcomes as measured goals, never guarantees

## Validation

- article packet parses as JSON
- both workflow files parse as YAML
- changed skills and commands pass repository frontmatter/alignment contracts
- Agent Alignment Check and CI pass on the current head
- branch is cleanly mergeable into `main`
- no production site was deployed or modified

## Follow-up after merge

Use one real, source-complete article as a proof run before enabling bulk content or social automation.