### PR TITLE
ci: fix malformed schedule key — health-check cron has never fired

### DIFF
--- a/.github/workflows/acos-health-check.yml
+++ b/.github/workflows/acos-health-check.yml
@@ -2,6 +2,7 @@ name: ACOS Health Check
 
 on:
   schedule:
+    - cron: '0 6 * * *'   # daily 06:00 UTC — no cadence specified in file/name, defaulting to daily per estate cost-discipline rule
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
The acos-health-check workflow's empty `schedule:` key meant its cron trigger silently never ran. Sets daily 06:00 UTC. Over-budget note: urgent one-line CI repair, merged immediately by the landing session — net queue change zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a daily automated health check scheduled for 06:00 UTC.
  * Existing manual and push-triggered health checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->